### PR TITLE
Use copies of GridRows to eliminate DOM thrashing

### DIFF
--- a/src/js/core/factories/GridRenderContainer.js
+++ b/src/js/core/factories/GridRenderContainer.js
@@ -12,7 +12,7 @@ angular.module('ui.grid')
    * @param {Grid} grid the grid the render container is in
    * @param {object} options the render container options
    */
-.factory('GridRenderContainer', ['gridUtil', function(gridUtil) {
+.factory('GridRenderContainer', ['gridUtil', 'GridRow', function(gridUtil, GridRow) {
   function GridRenderContainer(name, grid, options) {
     var self = this;
 
@@ -247,7 +247,12 @@ angular.module('ui.grid')
   GridRenderContainer.prototype.setRenderedRows = function setRenderedRows(newRows) {
     this.renderedRows.length = newRows.length;
     for (var i = 0; i < newRows.length; i++) {
-      this.renderedRows[i] = newRows[i];
+      if (this.renderedRows[i]) {
+        this.renderedRows[i].copyFrom(newRows[i]);
+      } else {
+        this.renderedRows[i] = newRows[i].clone();
+        this.renderedRows[i].renderId = i;
+      }
     }
   };
 

--- a/src/js/core/factories/GridRow.js
+++ b/src/js/core/factories/GridRow.js
@@ -56,6 +56,21 @@ angular.module('ui.grid')
     this.height = grid.options.rowHeight;
   }
 
+  GridRow.prototype.clone = function() {
+    var copy = new GridRow(this.entity, null, this.grid);
+    copy.uid = this.uid;
+    copy.visible = this.visible;
+    copy.height = this.height;
+    return copy;
+  };
+
+  GridRow.prototype.copyFrom = function(sourceRow) {
+    this.entity = sourceRow.entity;
+    this.uid = sourceRow.uid;
+    this.visible = sourceRow.visible;
+    this.height = sourceRow.height;
+  };
+
   /**
    * @ngdoc function
    * @name getQualifiedColField

--- a/src/templates/ui-grid/uiGridViewport.html
+++ b/src/templates/ui-grid/uiGridViewport.html
@@ -1,6 +1,6 @@
 <div class="ui-grid-viewport">
   <div class="ui-grid-canvas">
-    <div ng-repeat="(rowRenderIndex, row) in rowContainer.renderedRows track by row.uid" class="ui-grid-row" ng-style="containerCtrl.rowStyle(rowRenderIndex)">
+    <div ng-repeat="(rowRenderIndex, row) in rowContainer.renderedRows track by row.renderId" class="ui-grid-row" ng-style="containerCtrl.rowStyle(rowRenderIndex)">
       <div ui-grid-row="row" row-render-index="rowRenderIndex"></div>
     </div>
   </div>


### PR DESCRIPTION
I've been experimenting and profiling (with IE11), and the way the `renderedRows` array was being updated was causing the `uiGridViewport` contents to be completely re-rendered by Angular on scrolling.

This change basically creates a separate set of `GridRow`s in the `renderedRows` array, then copies the values from `newRows` into them instead of replacing the elements in the array.

I don't know what I've missed with this, I've probably broken a ton of stuff, but... check the performance difference out in Chrome. :dash: