### PR TITLE
Enh(cellNav) #2186 select multiple cells

### DIFF
--- a/misc/tutorial/202_cellnav.ngdoc
+++ b/misc/tutorial/202_cellnav.ngdoc
@@ -17,6 +17,9 @@ remembering the state of a page and scrolling back to that position when a user 
 
 Provides an example of scrolling to and setting the focus on a specific cell, using the scrollToFocus api.
 
+Provides an example of utilizing the modifierKeysToMultiSelectCells option and getCurrentSelection API function to
+extract values of selected cells.
+
 @example
 <example module="app">
   <file name="app.js">
@@ -24,7 +27,7 @@ Provides an example of scrolling to and setting the focus on a specific cell, us
 
     app.controller('MainCtrl', ['$scope', '$http', '$log', function ($scope, $http, $log) {
       $scope.gridOptions = {};
-
+      $scope.gridOptions.modifierKeysToMultiSelectCells = true;
       $scope.gridOptions.columnDefs = [
         { name: 'id', width:'150' },
         { name: 'name', width:'200' },
@@ -51,6 +54,15 @@ Provides an example of scrolling to and setting the focus on a specific cell, us
           if(rowCol !== null) {
               $scope.currentFocused = 'Row Id:' + rowCol.row.entity.id + ' col:' + rowCol.col.colDef.name;
           }
+        };
+
+        $scope.getCurrentSelection = function() {
+          var values = [];
+          var currentSelection = $scope.gridApi.cellNav.getCurrentSelection();
+          for (var i = 0; i < currentSelection.length; i++) {
+            values.push(currentSelection[i].row.entity[currentSelection[i].col.name])
+          }
+          $scope.printSelection = values.toString();
         };
         
         $scope.scrollTo = function( rowIndex, colIndex ) {
@@ -82,6 +94,8 @@ Provides an example of scrolling to and setting the focus on a specific cell, us
       <button type="button" class="btn btn-success" ng-click="scrollTo(50,7)">Scroll To Row 50, Balance</button>
       <button type="button" class="btn btn-success" ng-click="scrollToFocus(50,7)">Focus Row 50, Balance</button>
       <button type="button" class="btn btn-success" ng-click="getCurrentFocus()">Get Current focused cell</button>  <span ng-bind="currentFocused"></span>
+      <button type="button" class="btn btn-success" ng-click="getCurrentSelection()">Get Current focused cell values</button>
+      <input type="text" ng-model="printSelection" placeholder="Click the 'Get current focused cell values' button to print cell values of selection here" class="printSelection">
       <br>
       <br>
       <div ui-grid="gridOptions" ui-grid-cellNav ui-grid-pinning class="grid"></div>
@@ -91,6 +105,10 @@ Provides an example of scrolling to and setting the focus on a specific cell, us
     .grid {
       width: 500px;
       height: 400px;
+    }
+    .printSelection {
+        width: 600px;
+        margin-top: 10px;
     }
   </file>
 </example>

--- a/src/features/cellnav/js/cellnav.js
+++ b/src/features/cellnav/js/cellnav.js
@@ -249,6 +249,9 @@
           //create variables for state
           grid.cellNav = {};
           grid.cellNav.lastRowCol = null;
+          grid.cellNav.focusedCells = [];
+
+          service.defaultGridOptions(grid.options);
 
           /**
            *  @ngdoc object
@@ -312,6 +315,38 @@
                  */
                 getFocusedCell: function () {
                   return grid.cellNav.lastRowCol;
+                },
+
+                /**
+                 * @ngdoc function
+                 * @name getCurrentSelection
+                 * @methodOf  ui.grid.cellNav.api:PublicApi
+                 * @description returns an array containing the current selection
+                 * <br> array is empty if no selection has occurred
+                 */
+                getCurrentSelection: function () {
+                  return grid.cellNav.focusedCells;
+                },
+
+                /**
+                 * @ngdoc function
+                 * @name rowColSelectIndex
+                 * @methodOf  ui.grid.cellNav.api:PublicApi
+                 * @description returns the index in the order in which the RowCol was selected, returns -1 if the RowCol
+                 * isn't selected
+                 * @param {object} rowCol the rowCol to evaluate
+                 */
+                rowColSelectIndex: function (rowCol) {
+                  //return gridUtil.arrayContainsObjectWithProperty(grid.cellNav.focusedCells, 'col.uid', rowCol.col.uid) &&
+                  var index = -1;
+                  for (var i = 0; i < grid.cellNav.focusedCells.length; i++) {
+                    if (grid.cellNav.focusedCells[i].col.uid === rowCol.col.uid &&
+                      grid.cellNav.focusedCells[i].row.uid === rowCol.row.uid) {
+                      index = i;
+                      break;
+                    }
+                  }
+                  return index;
                 }
               }
             }
@@ -320,6 +355,26 @@
           grid.api.registerEventsFromObject(publicApi.events);
 
           grid.api.registerMethodsFromObject(publicApi.methods);
+
+        },
+
+        defaultGridOptions: function (gridOptions) {
+          /**
+           *  @ngdoc object
+           *  @name ui.grid.cellNav.api:GridOptions
+           *
+           *  @description GridOptions for cellNav feature, these are available to be
+           *  set using the ui-grid {@link ui.grid.class:GridOptions gridOptions}
+           */
+
+          /**
+           *  @ngdoc object
+           *  @name modifierKeysToMultiSelectCells
+           *  @propertyOf  ui.grid.cellNav.api:GridOptions
+           *  @description Enable multiple cell selection only when using the ctrlKey or shiftKey.
+           *  <br/>Defaults to false
+           */
+          gridOptions.modifierKeysToMultiSelectCells = gridOptions.modifierKeysToMultiSelectCells === true;
 
         },
 
@@ -508,11 +563,11 @@
             var seekRowIndex = grid.renderContainers.body.visibleRowCache.indexOf(gridRow);
             var totalRows = grid.renderContainers.body.visibleRowCache.length;
             var percentage = ( seekRowIndex + ( seekRowIndex / ( totalRows - 1 ) ) ) / totalRows;
-            args.y = { percentage:  percentage  };
+            args.y = { percentage: percentage  };
           }
 
           if (gridCol !== null) {
-            args.x = { percentage: this.getLeftWidth(grid, gridCol) / this.getLeftWidth(grid, grid.renderContainers.body.visibleColumnCache[grid.renderContainers.body.visibleColumnCache.length - 1] ) };
+            args.x = { percentage: this.getLeftWidth(grid, gridCol) / this.getLeftWidth(grid, grid.renderContainers.body.visibleColumnCache[grid.renderContainers.body.visibleColumnCache.length - 1]) };
           }
 
           if (args.y || args.x) {
@@ -766,19 +821,33 @@
               };
 
               //  gridUtil.logDebug('uiGridEdit preLink');
-              uiGridCtrl.cellNav.broadcastCellNav = grid.cellNav.broadcastCellNav = function (newRowCol) {
-                _scope.$broadcast(uiGridCellNavConstants.CELL_NAV_EVENT, newRowCol);
-                uiGridCtrl.cellNav.broadcastFocus(newRowCol);
+              uiGridCtrl.cellNav.broadcastCellNav = grid.cellNav.broadcastCellNav = function (newRowCol, modifierDown) {
+                modifierDown = !(modifierDown === undefined || !modifierDown);
+                uiGridCtrl.cellNav.broadcastFocus(newRowCol, modifierDown);
+                _scope.$broadcast(uiGridCellNavConstants.CELL_NAV_EVENT, newRowCol, modifierDown);
               };
 
-              uiGridCtrl.cellNav.broadcastFocus = function (rowCol) {
-                var row = rowCol.row,
-                    col = rowCol.col;
+              uiGridCtrl.cellNav.broadcastFocus = function (rowCol, modifierDown) {
+                modifierDown = !(modifierDown === undefined || !modifierDown);
 
-                if (grid.cellNav.lastRowCol === null || (grid.cellNav.lastRowCol.row !== row || grid.cellNav.lastRowCol.col !== col)) {
+                var row = rowCol.row,
+                  col = rowCol.col;
+
+                var rowColSelectIndex = uiGridCtrl.grid.api.cellNav.rowColSelectIndex(rowCol);
+
+                if (grid.cellNav.lastRowCol === null || rowColSelectIndex === -1) {
                   var newRowCol = new RowCol(row, col);
                   grid.api.cellNav.raise.navigate(newRowCol, grid.cellNav.lastRowCol);
                   grid.cellNav.lastRowCol = newRowCol;
+                  if (uiGridCtrl.grid.options.modifierKeysToMultiSelectCells && modifierDown) {
+                    grid.cellNav.focusedCells.push(rowCol);
+                  } else {
+                    grid.cellNav.focusedCells = [rowCol];
+                  }
+                } else if (grid.options.modifierKeysToMultiSelectCells && modifierDown &&
+                  rowColSelectIndex >= 0) {
+
+                  grid.cellNav.focusedCells.splice(rowColSelectIndex, 1);
                 }
               };
 
@@ -832,11 +901,12 @@
           return {
             post: function ($scope, $elm, $attrs, controllers) {
               var uiGridCtrl = controllers[0],
-                  renderContainerCtrl = controllers[1],
-                  cellNavController = controllers[2];
+                 renderContainerCtrl = controllers[1],
+                 cellNavController = controllers[2];
 
               // Skip attaching cell-nav specific logic if the directive is not attached above us
               if (!cellNavController) { return; }
+
 
               var containerId = renderContainerCtrl.containerId;
 
@@ -919,23 +989,28 @@
 
           // When a cell is clicked, broadcast a cellNav event saying that this row+col combo is now focused
           $elm.find('div').on('click', function (evt) {
-            uiGridCtrl.cellNav.broadcastCellNav(new RowCol($scope.row, $scope.col));
+            uiGridCtrl.cellNav.broadcastCellNav(new RowCol($scope.row, $scope.col), evt.ctrlKey || evt.metaKey);
 
             evt.stopPropagation();
           });
 
           // This event is fired for all cells.  If the cell matches, then focus is set
-          $scope.$on(uiGridCellNavConstants.CELL_NAV_EVENT, function (evt, rowCol) {
+          $scope.$on(uiGridCellNavConstants.CELL_NAV_EVENT, function (evt, rowCol, modifierDown) {
             if (rowCol.row === $scope.row &&
               rowCol.col === $scope.col) {
-              setFocused();
+              if (uiGridCtrl.grid.options.modifierKeysToMultiSelectCells && modifierDown &&
+                uiGridCtrl.grid.api.cellNav.rowColSelectIndex(rowCol) === -1) {
+                clearFocus();
+              } else {
+                setFocused();
+              }
 
               // This cellNav event came from a keydown event so we can safely refocus
               if (rowCol.hasOwnProperty('eventType') && rowCol.eventType === uiGridCellNavConstants.EVENT_TYPE.KEYDOWN) {
                 $elm.find('div')[0].focus();
               }
             }
-            else {
+            else if (!(uiGridCtrl.grid.options.modifierKeysToMultiSelectCells && modifierDown)) {
               clearFocus();
             }
           });

--- a/src/features/cellnav/test/uiGridCellNavDirective.spec.js
+++ b/src/features/cellnav/test/uiGridCellNavDirective.spec.js
@@ -1,6 +1,7 @@
 describe('ui.grid.cellNav directive', function () {
   var $scope, $compile, elm, uiGridConstants;
 
+  beforeEach(module('ui.grid'));
   beforeEach(module('ui.grid.cellNav'));
 
   beforeEach(inject(function (_$rootScope_, _$compile_, _uiGridConstants_) {
@@ -9,18 +10,41 @@ describe('ui.grid.cellNav directive', function () {
     uiGridConstants = _uiGridConstants_;
 
     $scope.gridOpts = {
-      data: [{ name: 'Bob' }]
+      data: [{ name: 'Bob' }, {name: 'Mathias'}, {name: 'Fred'}],
+      modifierKeysToMultiSelectCells: true
     };
-  }));
 
-  it('should not throw exceptions when scrolling when a grid does NOT have the ui-grid-cellNav directive', function () {
-    elm = angular.element('<div ui-grid="gridOpts"></div>');
+    $scope.gridOpts.onRegisterApi = function (gridApi) {
+      $scope.gridApi = gridApi;
+      $scope.grid = gridApi.grid;
+    };
+
+    elm = angular.element('<div ui-grid="gridOpts" ui-grid-cellNav></div>');
 
     $compile(elm)($scope);
     $scope.$digest();
+  }));
 
+  it('should not throw exceptions when scrolling when a grid does NOT have the ui-grid-cellNav directive', function () {
     expect(function () {
       $scope.$broadcast(uiGridConstants.events.GRID_SCROLL, {});
     }).not.toThrow();
+  });
+
+
+  it('rowColSelectIndex(rowCol) should properly return the index of the provided rowCol representing the order it was' +
+    ' selected', function () {
+    var rowColToTest = { row: $scope.grid.rows[0], col: $scope.grid.columns[0] };
+    // We select an arbitrary cell first to test that holding modifier persists the selection
+    $scope.grid.cellNav.broadcastCellNav({ row: $scope.grid.rows[1], col: $scope.grid.columns[0] }, true);
+    $scope.grid.cellNav.broadcastCellNav(rowColToTest, true);
+    // Now our rowColToTest should have the index 1 as it was selected second
+    expect($scope.gridApi.cellNav.rowColSelectIndex(rowColToTest)).toEqual(1);
+  });
+
+  it('getCurrentSelection() should properly return an array representing the values of the current cell selection', function () {
+    $scope.grid.cellNav.broadcastCellNav({ row: $scope.grid.rows[0], col: $scope.grid.columns[0] }, true);
+    $scope.grid.cellNav.broadcastCellNav({ row: $scope.grid.rows[1], col: $scope.grid.columns[0] }, true);
+    expect($scope.gridApi.cellNav.getCurrentSelection().length).toEqual(2);
   });
 });


### PR DESCRIPTION
Add modifierKeysToMultiSelectCells option which enables user to,
when including cellNav, hold the modifier key to select multiple
cells with the mouse. Add API method getCurrentSelection which
enables the user to get the cells currently selected.