### PR TITLE
Fix #2461: let the parent container scroll also on touchmove event

### DIFF
--- a/src/js/core/directives/ui-grid-render-container.js
+++ b/src/js/core/directives/ui-grid-render-container.js
@@ -172,8 +172,6 @@
                 event = event.originalEvent;
               }
 
-              event.preventDefault();
-
               var deltaX, deltaY, newX, newY;
               newX = event.targetTouches[0].screenX;
               newY = event.targetTouches[0].screenY;
@@ -205,6 +203,11 @@
                 scrollEvent.x = { percentage: scrollXPercentage, pixels: deltaX };
               }
 
+              // Let the parent container scroll if the grid is already at the top/bottom
+              if ((scrollEvent.y && scrollEvent.y.percentage !== 0 && scrollEvent.y.percentage !== 1) ||
+                  (scrollEvent.x && scrollEvent.x.percentage !== 0 && scrollEvent.x.percentage !== 1)) {
+                event.preventDefault();
+              }
               scrollEvent.fireScrollingEvent();
             }
             


### PR DESCRIPTION
A follow-up commit to 924af44b7ac7c3087d24427cc5904707da5cdf85 @kenwarner