### PR TITLE
select cells on mousedown, so it works also when mouseup is fired on different cell ( from the same row )

### DIFF
--- a/src/features/selection/js/selection.js
+++ b/src/features/selection/js/selection.js
@@ -684,7 +684,7 @@
                 }
               });
 
-              $elm.on('click', function (evt) {
+              $elm.on('mousedown', function (evt) {
                 selectCells(evt);
               });
             }


### PR DESCRIPTION
this is needed so the selection works also when, for example, you are selecting the text inside
a cell, using the mouse, but the mouseup will be triggered on a cell near the one with selection;