### PR TITLE
add utf-8 support on csv export

### DIFF
--- a/src/features/exporter/js/exporter.js
+++ b/src/features/exporter/js/exporter.js
@@ -744,14 +744,14 @@
       
           // IE10+
           if (navigator.msSaveBlob) {
-            return navigator.msSaveBlob(new Blob([csvContent], {
+            return navigator.msSaveBlob(new Blob(["\ufeff", csvContent], {
               type: strMimeType
             }), fileName);
           }
       
           //html5 A[download]
           if ('download' in a) {
-            var blob = new Blob([csvContent], {
+            var blob = new Blob(["\ufeff", csvContent], {
               type: strMimeType
             });
             rawFile = URL.createObjectURL(blob);


### PR DESCRIPTION
This sets exports to use UTF-8. This prevents encoding errors in some spreadsheet programs such as excel.