### PR TITLE
select cells on mousedown, so it works also when mouseup is fired on different cell ( from the same row )

### DIFF
--- a/src/features/selection/js/selection.js
+++ b/src/features/selection/js/selection.js
@@ -719,7 +719,7 @@
                 $elm.addClass('ui-grid-disable-selection');
                 $elm.on('touchstart', touchStart);
                 $elm.on('touchend', touchEnd);
-                $elm.on('click', selectCells);
+                $elm.on('mousedown', selectCells);
 
                 $scope.registered = true;
               }
@@ -731,7 +731,7 @@
 
                 $elm.off('touchstart', touchStart);
                 $elm.off('touchend', touchEnd);
-                $elm.off('click', selectCells);
+                $elm.off('mousedown', selectCells);
 
                 $scope.registered = false;
               }


### PR DESCRIPTION
this is needed, so for example, if you start to select the text content of a cell with the mouse, and the
mouseup will be on the next/prev cell from the same row, the selection is still set