### PR TITLE
Fix #2542 (renderContainer): mis-render on 401 on initial render

### DIFF
--- a/src/js/core/directives/ui-pinned-container.js
+++ b/src/js/core/directives/ui-pinned-container.js
@@ -27,7 +27,7 @@
                 var width = 0;
                 for (var i = 0; i < cols.length; i++) {
                   var col = cols[i];
-                  width += col.drawnWidth;
+                  width += col.drawnWidth || col.width || 0;
                 }
 
                 myWidth = width;
@@ -57,7 +57,7 @@
             }
 
             grid.renderContainers.body.registerViewportAdjuster(function (adjustment) {
-              if ( myWidth === 0 ){
+              if ( myWidth === 0 || !myWidth ){
                 updateContainerWidth();
               }
               // Subtract our own width


### PR DESCRIPTION
Sometimes width of the header or the canvas were calculated as NaN,
which looks to be a race condition.  Two fixes:

- Use width when drawnWidth not available.  Will potentially fail
if with is '*' or a percentage, but seems to work fine for now
- Call updateWidth if width isn't present