### PR TITLE
Add Index for Row Indexing

### DIFF
--- a/src/js/core/factories/GridRow.js
+++ b/src/js/core/factories/GridRow.js
@@ -47,13 +47,21 @@ angular.module('ui.grid')
     // Default to true
     this.visible = true;
 
-  /**
+    /**
     *  @ngdoc object
     *  @name height
     *  @propertyOf  ui.grid.class:GridRow
     *  @description height of each individual row
     */
     this.height = grid.options.rowHeight;
+
+    /**
+      *  @ngdoc object
+      *  @name index
+      *  @propertyOf  ui.grid.class:GridRow
+      *  @description Generate an index and add to a new column
+      */
+    this.index = grid.options.data.indexOf(entity);
   }
 
   /**


### PR DESCRIPTION
Allows for the row to be indexed with a new column corresponding to the data in the view.
Example of adding the column using a controller:
colDefs.push({'name': 'Index', 'displayName': 'Index', 'width': '60', 'visible': true,
               'cellTemplate': '<div class=\"ui-grid-cell-contents\">{{grid.options.paginationPageSize*(grid.options.paginationCurrentPage-1)+row.index+1 }}</div>', });

![screen shot 2015-01-16 at 1 26 07 pm](https://cloud.githubusercontent.com/assets/8193116/5781782/772341ea-9d83-11e4-93ee-a3a4b173ea5e.png)
