### PR TITLE
Fix Error: container.visibleRowCache is undefined.

### DIFF
--- a/src/js/core/factories/Grid.js
+++ b/src/js/core/factories/Grid.js
@@ -1148,7 +1148,7 @@ angular.module('ui.grid')
       var container = self.renderContainers[i];
 
       container.canvasHeightShouldUpdate = true;
-      container.visibleRowCache.length = 0;
+      container.visibleRowCache = [];
     }
     
     // rows.forEach(function (row) {


### PR DESCRIPTION
Replace
container.visibleRowCache.length = 0;
With
 container.visibleRowCache= [];
Because empty array is being considered as undefined which doesn't have a property called length