### PR TITLE
Fix missing final column border issue

### DIFF
--- a/src/features/selection/templates/selectionHeaderCell.html
+++ b/src/features/selection/templates/selectionHeaderCell.html
@@ -1,5 +1,5 @@
 <div>
-  <div class="ui-grid-vertical-bar">&nbsp;</div>
+  <!-- <div class="ui-grid-vertical-bar">&nbsp;</div> -->
   <div class="ui-grid-cell-contents" col-index="renderIndex">
     <ui-grid-selection-select-all-buttons ng-if="grid.options.enableSelectAll"></ui-grid-selection-select-all-buttons>
   </div>

--- a/src/less/cell.less
+++ b/src/less/cell.less
@@ -11,7 +11,7 @@
   box-sizing: border-box;
 
   &:last-child {
-    border-right: 0;
+    // border-right: 0;
   }
 }
 

--- a/src/less/footer.less
+++ b/src/less/footer.less
@@ -60,12 +60,6 @@
   }
 }
 
-// Make vertical bar in header row fill the height of the cell completely
-.ui-grid-footer .ui-grid-vertical-bar {
-  top: 0;
-  bottom: 0;
-}
-
 input[type="text"].ui-grid-filter-input {
   padding: 0;
   margin: 0;

--- a/src/less/header.less
+++ b/src/less/header.less
@@ -51,6 +51,8 @@
   top: 0;
   bottom: 0;
   background-color: inherit;
+  border-right: @gridBorderWidth solid;
+  border-color: @headerVerticalBarColor;
 
   .user-select(none);
 

--- a/src/less/rtl.less
+++ b/src/less/rtl.less
@@ -2,75 +2,79 @@
 * RTL Styles
 */
 
-.ui-grid[dir=rtl] .ui-grid-header-cell,
-.ui-grid[dir=rtl] .ui-grid-footer-cell,
-.ui-grid[dir=rtl] .ui-grid-cell {
-  float: right !important;
-}
+.ui-grid[dir=rtl] {
 
-// .ui-grid[dir=rtl] .ui-grid-scrollbar-vertical {
-//   right: inherit;
-//   left: 4px;
-// }
-
-.ui-grid[dir=rtl] .ui-grid-scrollbar-horizontal {
-  left: inherit;
-  right: 0;
-}
-
-.ui-grid[dir=rtl] .ui-grid-native-scrollbar.vertical {
-  left: 0;
-  right: inherit;
-}
-
-.ui-grid[dir=rtl] .ui-grid-column-menu-button {
-  position: absolute;
-  left: 1px;
-  top: 0;
-  right: inherit;
-}
-
-.ui-grid[dir=rtl] .ui-grid-cell:first-child,
-.ui-grid[dir=rtl] .ui-grid-header-cell:first-child,
-.ui-grid[dir=rtl] .ui-grid-footer-cell:first-child {
-  border-right: 0;
-}
-
-.ui-grid[dir=rtl] .ui-grid-cell:last-child {
-  border-right: @gridBorderWidth solid;
-  border-color: @borderColor;
-}
-
-.ui-grid[dir=rtl] .ui-grid-header-cell:first-child .ui-grid-vertical-bar,
-.ui-grid[dir=rtl] .ui-grid-footer-cell:first-child .ui-grid-vertical-bar,
-.ui-grid[dir=rtl] .ui-grid-cell:first-child .ui-grid-vertical-bar {
-  width: 0;
-}
-
-.ui-grid[dir=rtl] .ui-grid-menu-button {
-  z-index: 2;
-  position: absolute;
-  left: 0;
-  right: auto;
-  background: @headerBackgroundColor;
-  border: @gridBorderWidth solid @borderColor;
-  cursor: pointer;
-  min-height: 27px;
-  font-weight: normal;
-}
-
-.ui-grid[dir=rtl] .ui-grid-menu-button .ui-grid-menu {
-  left: 0;
-  right: auto;
-}
-
-// Position filter-cancel button on the left for rtl grids
-.ui-grid[dir="rtl"] .ui-grid-filter-container .ui-grid-filter-button {
-  right: initial;
-  left: 0;
-
-  [class^="ui-grid-icon"] {
-    right: initial;
-    left: 10px;
+  .ui-grid-header-cell,
+  .ui-grid-footer-cell,
+  .ui-grid-cell {
+    float: right !important;
   }
+
+  // .ui-grid-scrollbar-vertical {
+  //   right: inherit;
+  //   left: 4px;
+  // }
+
+  .ui-grid-scrollbar-horizontal {
+    left: inherit;
+    right: 0;
+  }
+
+  .ui-grid-native-scrollbar.vertical {
+    left: 0;
+    right: inherit;
+  }
+
+  .ui-grid-column-menu-button {
+    position: absolute;
+    left: 1px;
+    top: 0;
+    right: inherit;
+  }
+
+  .ui-grid-cell:first-child,
+  .ui-grid-header-cell:first-child,
+  .ui-grid-footer-cell:first-child {
+    border-right: 0;
+  }
+
+  .ui-grid-cell:last-child, .ui-grid-header-cell:last-child  {
+    border-left: @gridBorderWidth solid;
+    border-color: @borderColor;
+  }
+
+  .ui-grid-header-cell:first-child .ui-grid-vertical-bar,
+  .ui-grid-footer-cell:first-child .ui-grid-vertical-bar,
+  .ui-grid-cell:first-child .ui-grid-vertical-bar {
+    width: 0;
+  }
+
+  .ui-grid-menu-button {
+    z-index: 2;
+    position: absolute;
+    left: 0;
+    right: auto;
+    background: @headerBackgroundColor;
+    border: @gridBorderWidth solid @borderColor;
+    cursor: pointer;
+    min-height: 27px;
+    font-weight: normal;
+  }
+
+  .ui-grid-menu-button .ui-grid-menu {
+    left: 0;
+    right: auto;
+  }
+
+  // Position filter-cancel button on the left for rtl grids
+  .ui-grid-filter-container .ui-grid-filter-button {
+    right: initial;
+    left: 0;
+
+    [class^="ui-grid-icon"] {
+      right: initial;
+      left: 10px;
+    }
+  }
+
 }

--- a/src/templates/ui-grid/uiGridHeaderCell.html
+++ b/src/templates/ui-grid/uiGridHeaderCell.html
@@ -1,5 +1,5 @@
 <div ng-class="{ 'sortable': sortable }">
-  <div class="ui-grid-vertical-bar">&nbsp;</div>
+  <!-- <div class="ui-grid-vertical-bar">&nbsp;</div> -->
   <div class="ui-grid-cell-contents" col-index="renderIndex">
     <span>{{ col.displayName CUSTOM_FILTERS }}</span>
 


### PR DESCRIPTION
This would fix #2579.

I refactored the RTL less hierarchy so it's not as verbose and more readable. I also replaced the vertical-bar div elements with actual CSS borders. This should have a nice effect of removing 1 DOM elements per-cell, and so far I haven't seen any negative effects, including with increasing the grid's border size, but additional testing should be done.