### PR TITLE
added "isRowSelectable" to options

### DIFF
--- a/src/features/selection/js/selection.js
+++ b/src/features/selection/js/selection.js
@@ -425,6 +425,15 @@
            *  <br/>GridOptions.showFooter must also be set to true.
            */
           gridOptions.enableFooterTotalSelected = gridOptions.enableFooterTotalSelected !== false;
+
+          /**
+           *  @ngdoc object
+           *  @name isRowSelectable
+           *  @propertyOf  ui.grid.selection.api:GridOptions
+           *  @description Makes it possible to specify a method that evaluates for each and sets its "enableSelection" property.
+           */
+
+          gridOptions.isRowSelectable = angular.isDefined(gridOptions.isRowSelectable) ? gridOptions.isRowSelectable : angular.noop;
         },
 
         /**
@@ -631,6 +640,12 @@
                 };
 
                 uiGridCtrl.grid.addRowHeaderColumn(selectionRowHeaderDef);
+              }
+              
+              if (uiGridCtrl.grid.options.isRowSelectable !== angular.noop) {
+                uiGridCtrl.grid.registerRowBuilder(function(row, options) {
+                  row.enableSelection = uiGridCtrl.grid.options.isRowSelectable(row);
+                });
               }
             },
             post: function ($scope, $elm, $attrs, uiGridCtrl) {

--- a/src/features/selection/test/uiGridSelectionDirective.spec.js
+++ b/src/features/selection/test/uiGridSelectionDirective.spec.js
@@ -1,0 +1,55 @@
+describe('ui.grid.selection uiGridSelectionDirective', function() {
+  var parentScope,
+      elm,
+      scope,
+      gridCtrl;
+
+  beforeEach(module('ui.grid.selection'));
+
+  beforeEach(function() {
+    var rootScope;
+
+    inject([
+        '$rootScope',
+        function (rootScopeInj) {
+            rootScope = rootScopeInj;
+        }
+    ]);
+
+    parentScope = rootScope.$new();
+
+    parentScope.options = {
+      columnDefs : [{field: 'id'}]
+    };
+
+    parentScope.options.isRowSelectable = function(gridRow) {
+      return gridRow.entity.id % 2 === 0;
+    };
+
+    parentScope.options.data = [];
+    for (var i = 0; i < 10; i++) {
+      parentScope.options.data.push({id: i});
+    }
+
+    var tpl = '<div ui-grid="options" ui-grid-selection options="options"></div>';
+
+    inject([
+        '$compile',
+        function ($compile) {
+        elm = $compile(tpl)(parentScope);
+    }]);
+
+    parentScope.$digest();
+    scope = elm.scope();
+
+    gridCtrl = elm.controller('uiGrid');
+
+  });
+
+  it('should set the "enableSelection" field of the row using the function specified in "isRowSelectable"', function() {
+    for (var i = 0; i < gridCtrl.grid.rows.length; i++) {
+      var currentRow = gridCtrl.grid.rows[i];
+      expect(currentRow.enableSelection).toEqual(currentRow.entity.id % 2 === 0);
+    }
+  });
+});


### PR DESCRIPTION
The "isRowSelectable" is a new option that enables to add some logic to whether a row is selectable or not.

The value assigned to the option has to be a function that accepts a row as parameter and has to return a boolean that specifies if the given row is selectable or not.

Here is a sampe of such a function
```javascript
var options = {
  isRowSelectable: function(row) {
    // every row that has an entity with the name "Grid" is selectable
    return row.entity.name === 'Grid';
  }
}
```