### PR TITLE
Fix plunker: border-box style on headercell

### DIFF
--- a/src/features/resize-columns/test/resizeColumns.spec.js
+++ b/src/features/resize-columns/test/resizeColumns.spec.js
@@ -240,7 +240,7 @@ describe('ui.grid.resizeColumns', function () {
     });
 
     describe('and you double-click its resizer, the column width', function () {
-      it('should not go below the minWidth', function () {
+      it('should not go below the minWidth less border', function () {
         var firstResizer = $(grid).find('[ui-grid-column-resizer]').first();
 
         $(firstResizer).simulate('dblclick');
@@ -250,7 +250,7 @@ describe('ui.grid.resizeColumns', function () {
 
         var newWidth = $(grid).find('.' + uiGridConstants.COL_CLASS_PREFIX + firstColumnUid).first().width();
 
-        expect(newWidth >= minWidth).toEqual(true);
+        expect(newWidth >= (minWidth - 1)).toEqual(true);
       });
     });
 
@@ -268,12 +268,12 @@ describe('ui.grid.resizeColumns', function () {
         $scope.$digest();
       });
 
-      it('should not go below the minWidth', function () {
+      it('should not go below the minWidth less border', function () {
         var firstColumnUid = gridScope.grid.columns[0].uid;
 
         var newWidth = $(grid).find('.' + uiGridConstants.COL_CLASS_PREFIX + firstColumnUid).first().width();
 
-        expect(newWidth >= minWidth).toEqual(true);
+        expect(newWidth >= (minWidth - 1)).toEqual(true);
       });
     });
   });

--- a/src/less/header.less
+++ b/src/less/header.less
@@ -7,7 +7,7 @@
 
 .ui-grid-header {
   border-bottom: 1px solid @borderColor;
-  box-sizing: content-box;;
+  box-sizing: content-box;
 }
 
 .ui-grid-top-panel {
@@ -53,6 +53,7 @@
   background-color: inherit;
   border-right: @gridBorderWidth solid;
   border-color: @headerVerticalBarColor;
+  box-sizing: border-box;
 
   .user-select(none);
 

--- a/test/unit/core/directives/uiGridCell.spec.js
+++ b/test/unit/core/directives/uiGridCell.spec.js
@@ -114,7 +114,7 @@ describe('uiGridCell', function () {
 
     // The first column should be 100px wide because we said it should be
     expect(firstCol.outerWidth()).toEqual(100, 'first cell is 100px');
-    expect(firstHeaderCell.innerWidth()).toEqual(100, "header cell is 100px");
+    expect(firstHeaderCell.innerWidth()).toEqual(99, "header cell is 100px less border");
 
     // Now swap the columns in the column defs
     $scope.gridOptions.columnDefs = [{ field: 'age', width: 50 }, { field: 'name', width: 100 }];
@@ -129,13 +129,13 @@ describe('uiGridCell', function () {
 
     // The first column should now be 50px wide
     expect(firstColAgain.outerWidth()).toEqual(50, 'first cell again is 50');
-    expect(firstHeaderCellAgain.innerWidth()).toEqual(50, 'header cell again is 50px');
+    expect(firstHeaderCellAgain.innerWidth()).toEqual(49, 'header cell again is 50px less border');
 
     // ... and the last column should now be 100px wide
     var lastCol = $(gridElm).find('.ui-grid-cell').last();
     var lastHeaderCell = $(gridElm).find('.ui-grid-header-cell').last();
     expect(lastCol.outerWidth()).toEqual(100, 'last cell again is 100px');
-    expect(lastHeaderCell.innerWidth()).toEqual(100, 'last header cell again is 100px');
+    expect(lastHeaderCell.innerWidth()).toEqual(99, 'last header cell again is 100px less border');
 
     angular.element(gridElm).remove();
   }));


### PR DESCRIPTION
For me (but not for everyone) in plunker I'm getting the headers
wrapping.  The cause seems to be that the rightmost header cell
border doesn't have any space - so the whole header row
is 1px too wide.  No idea why that happens to me and nobody
else (well, not @swalters or @c0bra).

The header apparently needs content-box for height, aiming to
put border-box on the header-cell, which might sort things out.

This needs verifying on IE11, because the content-box change
was to fix IE11.