### PR TITLE
Fixed NOT_EQUAL filter

### DIFF
--- a/src/js/core/services/rowSearcher.js
+++ b/src/js/core/services/rowSearcher.js
@@ -209,7 +209,7 @@ module.service('rowSearcher', ['gridUtil', 'uiGridConstants', function (gridUtil
     }
 
     if (filter.condition === uiGridConstants.filter.NOT_EQUAL) {
-      return angular.equals(value, term);
+      return !angular.equals(value, term);
     }
 
     if (typeof(value) === 'number'){


### PR DESCRIPTION
`uiGridConstants.filter.NOT_EQUAL` was actually returning exact matches