### PR TITLE
scroll bug when scrolling down  #1926

### DIFF
--- a/src/js/core/directives/ui-grid-render-container.js
+++ b/src/js/core/directives/ui-grid-render-container.js
@@ -157,9 +157,9 @@
                 if ((scrollEvent.y && scrollEvent.y.percentage !== 0 && scrollEvent.y.percentage !== 1 && containerCtrl.viewport[0].scrollTop !== 0 ) ||
                     (scrollEvent.x && scrollEvent.x.percentage !== 0 && scrollEvent.x.percentage !== 1)) {
                   evt.preventDefault();
+                  scrollEvent.fireThrottledScrollingEvent();
               }
-
-              scrollEvent.fireThrottledScrollingEvent();
+              
             });
 
             var startY = 0,


### PR DESCRIPTION
>When scrolling up, the page continues scrolling when the grid's scroller reaches the top which is good. But the same doesn't happen when the grid's scroller is at the bottom

It seems that the fireThrottledScrollingEvent function had a conflict with the browser scrolling behavior  #1926