### PR TITLE
Add date flag to filters to be allow columns to be filtered by dates.

### DIFF
--- a/src/js/core/services/rowSearcher.js
+++ b/src/js/core/services/rowSearcher.js
@@ -134,7 +134,7 @@ module.service('rowSearcher', ['gridUtil', 'uiGridConstants', function (gridUtil
           newFilter.condition = rowSearcher.guessCondition(filter);
         }
 
-        newFilter.flags = angular.extend( { caseSensitive: false }, filter.flags );
+        newFilter.flags = angular.extend( { caseSensitive: false, date: false }, filter.flags );
 
         if (newFilter.condition === uiGridConstants.filter.STARTS_WITH) {
           newFilter.startswithRE = new RegExp('^' + newFilter.term, regexpFlags);
@@ -219,6 +219,12 @@ module.service('rowSearcher', ['gridUtil', 'uiGridConstants', function (gridUtil
       if (!isNaN(tempFloat)) {
         term = tempFloat;
       }
+    }
+
+    if (filter.flags.date === true) {
+      value = new Date(value);
+      // If the term has a dash in it, it comes through as '\-' -- we need to take out the '\'.
+      term = new Date(term.replace(/\\/g, ''));
     }
 
     if (filter.condition === uiGridConstants.filter.GREATER_THAN) {

--- a/test/unit/core/services/rowSearcher.spec.js
+++ b/test/unit/core/services/rowSearcher.spec.js
@@ -1,0 +1,40 @@
+describe('rowSearcher', function() {
+  var rowSearcher,
+    uiGridConstants;
+
+  beforeEach(module('ui.grid'));
+
+  beforeEach(inject(function(_rowSearcher_, _uiGridConstants_) {
+    rowSearcher = _rowSearcher_;
+    uiGridConstants = _uiGridConstants_;
+  }));
+
+  describe('runColumnFilter', function() {
+    it('should be able to compare dates', function() {
+      var grid = {
+        getCellValue: function() {
+          return '2015-05-23';
+        }
+      };
+
+      var filter = {
+        term: '2015-05-24',
+        flags: { date: true },
+        condition: uiGridConstants.filter.GREATER_THAN
+      };
+      expect(rowSearcher.runColumnFilter(grid, 1, 2, filter)).toBe(false);
+
+      filter.term = '2015-05-22';
+      filter.condition = uiGridConstants.filter.GREATER_THAN;
+      expect(rowSearcher.runColumnFilter(grid, 1, 2, filter)).toBe(true);
+
+      filter.term = '2015-05-24';
+      filter.condition = uiGridConstants.filter.GREATER_THAN;
+      expect(rowSearcher.runColumnFilter(grid, 1, 2, filter)).toBe(false);
+
+      filter.term = '2015-05-23';
+      filter.condition = uiGridConstants.filter.GREATER_THAN_OR_EQUAL_TO;
+      expect(rowSearcher.runColumnFilter(grid, 1, 2, filter)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Example use:

![image](https://cloud.githubusercontent.com/assets/398210/6187476/d4197ec6-b37e-11e4-8753-ac15776e81a2.png)

Code:

    columnDefs: [
        // ...
        {
            cellFilter: 'date:\'d MMM yyyy H:mm\'',
            displayName: 'Order Date',
            field: 'date',
            filters: [
                {
                    condition: uiGridConstants.filter.GREATER_THAN_OR_EQUAL,
                    placeholder: 'From',
                    flags: { date: true }
                },
                {
                    condition: uiGridConstants.filter.LESS_THAN_OR_EQUAL,
                    placeholder: 'To',
                    flags: { date: true }
                }
            ]
        }
        // ....
    ]