### PR TITLE
Bring back the 2.x menu behavior of custom menu templates.

### DIFF
--- a/src/js/core/directives/ui-grid-menu.js
+++ b/src/js/core/directives/ui-grid-menu.js
@@ -32,129 +32,147 @@ angular.module('ui.grid')
 
 .directive('uiGridMenu', ['$compile', '$timeout', '$window', '$document', 'gridUtil', 'uiGridConstants', 
 function ($compile, $timeout, $window, $document, gridUtil, uiGridConstants) {
+  var defaultTemplate = 'ui-grid/uiGridMenu';
   var uiGridMenu = {
     priority: 0,
     scope: {
       // shown: '&',
       menuItems: '=',
-      autoHide: '=?'
+      autoHide: '=?',
+      templateUrl: '='
     },
     require: '?^uiGrid',
-    templateUrl: 'ui-grid/uiGridMenu',
     replace: false,
-    link: function ($scope, $elm, $attrs, uiGridCtrl) {
-      var self = this;
-      var menuMid;
-      var $animate;
-     
-    // *** Show/Hide functions ******
-      self.showMenu = $scope.showMenu = function(event, args) {
-        if ( !$scope.shown ){
+    compile: function ($elm, $attrs) {
+      return {
+        pre: function ($scope, $elm, $attrs, uiGridCtrl) {
+          if ( uiGridCtrl ) {
+              $scope.grid = uiGridCtrl.grid;
+          }
 
-          /*
-           * In order to animate cleanly we remove the ng-if, wait a digest cycle, then
-           * animate the removal of the ng-hide.  We can't successfully (so far as I can tell)
-           * animate removal of the ng-if, as the menu items aren't there yet.  And we don't want
-           * to rely on ng-show only, as that leaves elements in the DOM that are needlessly evaluated
-           * on scroll events.
-           * 
-           * Note when testing animation that animations don't run on the tutorials.  When debugging it looks
-           * like they do, but angular has a default $animate provider that is just a stub, and that's what's
-           * being called.  ALso don't be fooled by the fact that your browser has actually loaded the 
-           * angular-translate.js, it's not using it.  You need to test animations in an external application. 
-           */
-          $scope.shown = true;
+          var menuTemplate = $scope.templateUrl || defaultTemplate;
+          gridUtil.getTemplate(menuTemplate)
+            .then(function (contents) {
+              var template = angular.element(contents);
+              $elm.append(template);
+              $compile(template)($scope);
+            });
+        },
 
-          $timeout( function() {
-            $scope.shownMid = true;
-            $scope.$emit('menu-shown');
-          });
-        } else if ( !$scope.shownMid ) {
-          // we're probably doing a hide then show, so we don't need to wait for ng-if
-          $scope.shownMid = true;
-          $scope.$emit('menu-shown');
-        }
+        post: function ($scope, $elm, $attrs, uiGridCtrl) {
+          var self = this;
+          var menuMid;
+          var $animate;
 
-        var docEventType = 'click';
-        if (args && args.originalEvent && args.originalEvent.type && args.originalEvent.type === 'touchstart') {
-          docEventType = args.originalEvent.type;
-        }
+          // *** Show/Hide functions ******
+          self.showMenu = $scope.showMenu = function(event, args) {
+            if ( !$scope.shown ){
 
-        // Turn off an existing document click handler
-        angular.element(document).off('click touchstart', applyHideMenu);
+              /*
+               * In order to animate cleanly we remove the ng-if, wait a digest cycle, then
+               * animate the removal of the ng-hide.  We can't successfully (so far as I can tell)
+               * animate removal of the ng-if, as the menu items aren't there yet.  And we don't want
+               * to rely on ng-show only, as that leaves elements in the DOM that are needlessly evaluated
+               * on scroll events.
+               * 
+               * Note when testing animation that animations don't run on the tutorials.  When debugging it looks
+               * like they do, but angular has a default $animate provider that is just a stub, and that's what's
+               * being called.  ALso don't be fooled by the fact that your browser has actually loaded the 
+               * angular-translate.js, it's not using it.  You need to test animations in an external application. 
+               */
+              $scope.shown = true;
 
-        // Turn on the document click handler, but in a timeout so it doesn't apply to THIS click if there is one
-        $timeout(function() {
-          angular.element(document).on(docEventType, applyHideMenu);
-        });
-      };
-
-
-      self.hideMenu = $scope.hideMenu = function(event, args) {
-        if ( $scope.shown ){
-          /*
-           * In order to animate cleanly we animate the addition of ng-hide, then use a $timeout to
-           * set the ng-if (shown = false) after the animation runs.  In theory we can cascade off the
-           * callback on the addClass method, but it is very unreliable with unit tests for no discernable reason.
-           *   
-           * The user may have clicked on the menu again whilst
-           * we're waiting, so we check that the mid isn't shown before applying the ng-if.
-           */
-          $scope.shownMid = false;
-          $timeout( function() {
-            if ( !$scope.shownMid ){
-              $scope.shown = false;
-              $scope.$emit('menu-hidden');
+              $timeout( function() {
+                $scope.shownMid = true;
+                $scope.$emit('menu-shown');
+              });
+            } else if ( !$scope.shownMid ) {
+              // we're probably doing a hide then show, so we don't need to wait for ng-if
+              $scope.shownMid = true;
+              $scope.$emit('menu-shown');
             }
-          }, 200);
-        }
 
-        angular.element(document).off('click touchstart', applyHideMenu);
-      };
+            var docEventType = 'click';
+            if (args && args.originalEvent && args.originalEvent.type && args.originalEvent.type === 'touchstart') {
+              docEventType = args.originalEvent.type;
+            }
 
-      $scope.$on('hide-menu', function (event, args) {
-        $scope.hideMenu(event, args);
-      });
+            // Turn off an existing document click handler
+            angular.element(document).off('click touchstart', applyHideMenu);
 
-      $scope.$on('show-menu', function (event, args) {
-        $scope.showMenu(event, args);
-      });
+            // Turn on the document click handler, but in a timeout so it doesn't apply to THIS click if there is one
+            $timeout(function() {
+              angular.element(document).on(docEventType, applyHideMenu);
+            });
+          };
 
-      
-    // *** Auto hide when click elsewhere ******
-      var applyHideMenu = function(){
-        if ($scope.shown) {
-          $scope.$apply(function () {
-            $scope.hideMenu();
+
+          self.hideMenu = $scope.hideMenu = function(event, args) {
+            if ( $scope.shown ){
+              /*
+               * In order to animate cleanly we animate the addition of ng-hide, then use a $timeout to
+               * set the ng-if (shown = false) after the animation runs.  In theory we can cascade off the
+               * callback on the addClass method, but it is very unreliable with unit tests for no discernable reason.
+               *   
+               * The user may have clicked on the menu again whilst
+               * we're waiting, so we check that the mid isn't shown before applying the ng-if.
+               */
+              $scope.shownMid = false;
+              $timeout( function() {
+                if ( !$scope.shownMid ){
+                  $scope.shown = false;
+                  $scope.$emit('menu-hidden');
+                }
+              }, 200);
+            }
+
+            angular.element(document).off('click touchstart', applyHideMenu);
+          };
+
+          $scope.$on('hide-menu', function (event, args) {
+            $scope.hideMenu(event, args);
           });
+
+          $scope.$on('show-menu', function (event, args) {
+            $scope.showMenu(event, args);
+          });
+
+          
+          // *** Auto hide when click elsewhere ******
+          var applyHideMenu = function(){
+            if ($scope.shown) {
+              $scope.$apply(function () {
+                $scope.hideMenu();
+              });
+            }
+          };
+        
+          if (typeof($scope.autoHide) === 'undefined' || $scope.autoHide === undefined) {
+            $scope.autoHide = true;
+          }
+
+          if ($scope.autoHide) {
+            angular.element($window).on('resize', applyHideMenu);
+          }
+
+          $scope.$on('$destroy', function () {
+            angular.element(document).off('click touchstart', applyHideMenu);
+          });
+
+
+          $scope.$on('$destroy', function() {
+            angular.element($window).off('resize', applyHideMenu);
+          });
+
+          if (uiGridCtrl) {
+           $scope.$on('$destroy', uiGridCtrl.grid.api.core.on.scrollEvent($scope, applyHideMenu ));
+          }
+
+          $scope.$on('$destroy', $scope.$on(uiGridConstants.events.ITEM_DRAGGING, applyHideMenu ));
         }
       };
-    
-      if (typeof($scope.autoHide) === 'undefined' || $scope.autoHide === undefined) {
-        $scope.autoHide = true;
-      }
-
-      if ($scope.autoHide) {
-        angular.element($window).on('resize', applyHideMenu);
-      }
-
-      $scope.$on('$destroy', function () {
-        angular.element(document).off('click touchstart', applyHideMenu);
-      });
-      
-
-      $scope.$on('$destroy', function() {
-        angular.element($window).off('resize', applyHideMenu);
-      });
-
-      if (uiGridCtrl) {
-       $scope.$on('$destroy', uiGridCtrl.grid.api.core.on.scrollEvent($scope, applyHideMenu ));
-      }
-
-      $scope.$on('$destroy', $scope.$on(uiGridConstants.events.ITEM_DRAGGING, applyHideMenu ));
     },
-    
-    
+
     controller: ['$scope', '$element', '$attrs', function ($scope, $element, $attrs) {
       var self = this;
     }]
@@ -164,6 +182,7 @@ function ($compile, $timeout, $window, $document, gridUtil, uiGridConstants) {
 }])
 
 .directive('uiGridMenuItem', ['gridUtil', '$compile', 'i18nService', function (gridUtil, $compile, i18nService) {
+  var defaultTemplate = 'ui-grid/uiGridMenuItem';
   var uiGridMenuItem = {
     priority: 0,
     scope: {
@@ -176,23 +195,19 @@ function ($compile, $timeout, $window, $document, gridUtil, uiGridConstants) {
       templateUrl: '='
     },
     require: ['?^uiGrid', '^uiGridMenu'],
-    templateUrl: 'ui-grid/uiGridMenuItem',
     replace: true,
     compile: function($elm, $attrs) {
       return {
         pre: function ($scope, $elm, $attrs, controllers) {
           var uiGridCtrl = controllers[0],
               uiGridMenuCtrl = controllers[1];
-          
-          if ($scope.templateUrl) {
-            gridUtil.getTemplate($scope.templateUrl)
-                .then(function (contents) {
-                  var template = angular.element(contents);
-                    
-                  var newElm = $compile(template)($scope);
-                  $elm.replaceWith(newElm);
-                });
-          }
+          var menuItemTemplate = $scope.templateUrl || defaultTemplate;
+          gridUtil.getTemplate(menuItemTemplate)
+            .then(function (contents) {
+              var template = angular.element(contents);
+              $compile(template)($scope);
+              $elm.replaceWith(template);
+            });
         },
         post: function ($scope, $elm, $attrs, controllers) {
           var uiGridCtrl = controllers[0],

--- a/src/js/core/factories/GridOptions.js
+++ b/src/js/core/factories/GridOptions.js
@@ -391,7 +391,40 @@ angular.module('ui.grid')
        * of a precompiled template (TBD how to use this).  Refer to the custom footer tutorial for more information.
        */
       baseOptions.footerTemplate = baseOptions.footerTemplate || null;
+   
+      /**
+       * @ngdoc string
+       * @name menuButtonTemplate
+       * @propertyOf ui.grid.class:GridOptions
+       * @description (optional) Null by default. When provided, this setting uses a custom grid menu
+       * template. Can be set to either the name of a template file 'menuButton_template.html', inline html
+       * <pre>'<div class="ui-grid-menu-button" ng-click="customToggleMenu()"><div class="ui-grid-icon-container"><i class="ui-grid-icon=menu">&nbsp;</i></div></div><div ui-grid-menu menu-items="menuItems"></div>'</pre>, or the id
+       * of a precompiled template (TBD how to use this).  Refer to the custom footer tutorial for more information.
+       */
+      baseOptions.menuButtonTemplate = baseOptions.menuButtonTemplate || null;
   
+      /**
+       * @ngdoc string
+       * @name menuTemplate
+       * @propertyOf ui.grid.class:GridOptions
+       * @description (optional) Null by default. When provided, this setting uses a custom grid menu
+       * template. Can be set to either the name of a template file 'menu_template.html', inline html
+       * <pre>'<div class="ui-grid-menu" style="text-align: left">Custom Menu Header <ul><li ng-repeat="item in menuItems" ui-grid-menu-item></li></ul></div>'</pre>, or the id
+       * of a precompiled template (TBD how to use this).  Refer to the custom footer tutorial for more information.
+       */
+      baseOptions.menuTemplate = baseOptions.menuTemplate || null;
+    
+      /**
+       * @ngdoc string
+       * @name menuItemTemplate
+       * @propertyOf ui.grid.class:GridOptions
+       * @description (optional) Null by default. When provided, this setting uses a custom grid menu item
+       * template. Can be set to either the name of a template file 'menuItem_template.html', inline html
+       * <pre>'<li class="ui-grid-menu-item"><label>{{name}}</label></li>'</pre>, or the id
+       * of a precompiled template (TBD how to use this).  Refer to the custom footer tutorial for more information.
+       */
+      baseOptions.menuItemTemplate = baseOptions.menuItemTemplate || null;
+   
       /**
        * @ngdoc string
        * @name rowTemplate

--- a/src/templates/ui-grid/ui-grid-menu-button.html
+++ b/src/templates/ui-grid/ui-grid-menu-button.html
@@ -2,5 +2,5 @@
   <div class="ui-grid-icon-container">
     <i class="ui-grid-icon-menu">&nbsp;</i>
   </div>
-  <div ui-grid-menu menu-items="menuItems"></div>
+  <div ui-grid-menu menu-items="menuItems" template-url="menuTemplate"></div>
 </div>

--- a/test/unit/core/factories/GridOptions.spec.js
+++ b/test/unit/core/factories/GridOptions.spec.js
@@ -45,6 +45,9 @@ describe('GridOptions factory', function () {
         rowEquality: jasmine.any(Function),
         headerTemplate: null,
         footerTemplate: null,
+        menuButtonTemplate: null,
+        menuTemplate: null,
+        menuItemTemplate: null,
         rowTemplate: 'ui-grid/ui-grid-row',
         appScopeProvider: null
       });
@@ -86,6 +89,9 @@ describe('GridOptions factory', function () {
         rowEquality: testFunction,
         headerTemplate: 'testHeader',
         footerTemplate: 'testFooter',
+        menuButtonTemplate: 'testMenuButton',
+        menuTemplate: 'testMenu',
+        menuItemTemplate: 'testMenuItem',
         rowTemplate: 'testRow',
         extraOption: 'testExtraOption',
         appScopeProvider : 'anotherRef'
@@ -124,6 +130,9 @@ describe('GridOptions factory', function () {
         rowEquality: testFunction,
         headerTemplate: 'testHeader',
         footerTemplate: 'testFooter',
+        menuButtonTemplate: 'testMenuButton',
+        menuTemplate: 'testMenu',
+        menuItemTemplate: 'testMenuItem',
         rowTemplate: 'testRow',
         extraOption: 'testExtraOption',
         appScopeProvider : 'anotherRef'
@@ -166,6 +175,9 @@ describe('GridOptions factory', function () {
         rowEquality: testFunction,
         headerTemplate: 'testHeader',
         footerTemplate: 'testFooter',
+        menuButtonTemplate: 'testMenuButton',
+        menuTemplate: 'testMenu',
+        menuItemTemplate: 'testMenuItem',
         rowTemplate: 'testRow',
         extraOption: 'testExtraOption'
       };
@@ -203,6 +215,9 @@ describe('GridOptions factory', function () {
         rowEquality: testFunction,
         headerTemplate: 'testHeader',
         footerTemplate: 'testFooter',
+        menuButtonTemplate: 'testMenuButton',
+        menuTemplate: 'testMenu',
+        menuItemTemplate: 'testMenuItem',
         rowTemplate: 'testRow',
         extraOption: 'testExtraOption',
         appScopeProvider : null


### PR DESCRIPTION
In 2.x it was possible to specify a custom menu template. In 3.0 the one grid menu has been split into 3 directives and custom templates are not possible. This pull request adds the ability to specify custom templates for menuButton, menu, and menuItem.