### PR TITLE
Fix (columnMenu): Fix #2852 positioning of column menu once scrolled

### DIFF
--- a/src/js/core/directives/ui-grid-column-menu.js
+++ b/src/js/core/directives/ui-grid-column-menu.js
@@ -241,6 +241,7 @@ function ( i18nService, uiGridConstants, gridUtil ) {
       var positionData = {};
       positionData.left = $columnElement[0].offsetLeft;
       positionData.top = $columnElement[0].offsetTop;
+      positionData.parentLeft = $columnElement[0].offsetParent.offsetLeft;
 
       // Get the grid scrollLeft
       positionData.offset = 0;
@@ -301,7 +302,7 @@ function ( i18nService, uiGridConstants, gridUtil ) {
         }
       }
       
-      var left = positionData.left + renderContainerOffset - containerScrollLeft + positionData.width - myWidth + paddingRight;
+      var left = positionData.left + renderContainerOffset - containerScrollLeft + positionData.parentLeft + positionData.width - myWidth + paddingRight;
       if (left < positionData.offset){
         left = positionData.offset;
       }


### PR DESCRIPTION
The column menus for columns to the right were in the wrong place. This
was due to the change to the header to use a table format, which also
appeared to include using offsetLeft on the parent to reflect virtualised
columns to the left.  Take this offsetLeft into account as well in the
column menu positioning calculations.