### PR TITLE
Fix (exporter): Fix #2313 export for IE9

### DIFF
--- a/src/features/exporter/js/exporter.js
+++ b/src/features/exporter/js/exporter.js
@@ -734,6 +734,18 @@
 
         /**
          * @ngdoc function
+         * @name isIE
+         * @methodOf  ui.grid.exporter.service:uiGridExporterService
+         * @description Checks whether current browser is IE and returns it's version if it is
+        */
+        isIE: function () {
+            var myNav = navigator.userAgent.toLowerCase();
+            return (myNav.indexOf('msie') !== -1) ? parseInt(myNav.split('msie')[1]) : false;
+        },
+
+
+        /**
+         * @ngdoc function
          * @name downloadFile
          * @methodOf  ui.grid.exporter.service:uiGridExporterService
          * @description Triggers download of a csv file.  Logic provided
@@ -749,6 +761,27 @@
           var strMimeType = 'application/octet-stream;charset=utf-8';
           var rawFile;
       
+          if (!fileName) {
+            var currentDate = new Date();
+            fileName = "CWS Export - " + currentDate.getFullYear() + (currentDate.getMonth() + 1) +
+                       currentDate.getDate() + currentDate.getHours() +
+                       currentDate.getMinutes() + currentDate.getSeconds() + ".csv";
+          }
+
+          if (this.isIE() < 10) {
+            var frame = D.createElement('iframe');
+            document.body.appendChild(frame);
+        
+            frame.contentWindow.document.open("text/html", "replace");
+            frame.contentWindow.document.write('sep=,\r\n' + csvContent);
+            frame.contentWindow.document.close();
+            frame.contentWindow.focus();
+            frame.contentWindow.document.execCommand('SaveAs', true, fileName);
+        
+            document.body.removeChild(frame);
+            return true;
+          }
+        
           // IE10+
           if (navigator.msSaveBlob) {
             return navigator.msSaveBlob(new Blob(["\ufeff", csvContent], {

--- a/src/less/body.less
+++ b/src/less/body.less
@@ -18,6 +18,7 @@
   overflow-y: scroll;
   -webkit-overflow-scrolling: touch;
 
+  // requested in #2312, IE9 compatibility with exporter.  I have no ability to test this, so assuming it's needed PaulL
   :focus {
     outline: none;
   }


### PR DESCRIPTION
Information and code provided by @alexandery.  I have no ability to test
it, but it should only impact IE9, which apparently doesn't work otherwise
anyway.

The main concern here is that this creates and destroys an iFrame in IE9,
and that iFrame apparently messes up formatting, so requires application of
width: auto !important; on the ui-grid-viewport.  That appears to break formatting
in chrome on all features tutorial, so I haven't applied it.  Presumably that means
formatting will be ugly in IE9.