### PR TITLE
Fix export bug around isIE

### DIFF
--- a/src/features/exporter/js/exporter.js
+++ b/src/features/exporter/js/exporter.js
@@ -760,6 +760,7 @@
           var a = D.createElement('a');
           var strMimeType = 'application/octet-stream;charset=utf-8';
           var rawFile;
+          var ieVersion;
       
           if (!fileName) {
             var currentDate = new Date();
@@ -768,7 +769,8 @@
                        currentDate.getMinutes() + currentDate.getSeconds() + ".csv";
           }
 
-          if (this.isIE() < 10) {
+          ieVersion = this.isIE();
+          if (ieVersion && ieVersion < 10) {
             var frame = D.createElement('iframe');
             document.body.appendChild(frame);
         


### PR DESCRIPTION
isIE() returns false when using browsers other than Internet Explorer,
but it worked as if using IE.

I tested in IE 11, Firefox 36.0, and Chrome 40.0.2214.115 m.

This pull request is related with #2312 and #2873.