### PR TITLE
Incorrect handle offset when moving column on Safari

### DIFF
--- a/src/features/move-columns/js/column-movable.js
+++ b/src/features/move-columns/js/column-movable.js
@@ -276,7 +276,15 @@
                         //Left of cloned element should be aligned to original header cell.
                         movingElm.addClass('movingColumn');
                         var movingElementStyles = {};
-                        var elmLeft = $elm[0].getBoundingClientRect().left;
+                        var elmLeft;
+                        if (gridUtil.detectBrowser() === 'safari') {
+                          //Correction for Safari getBoundingClientRect,
+                          //which does not correctly compute when there is an horizontal scroll
+                          elmLeft = $elm[0].offsetLeft + $elm[0].offsetWidth - $elm[0].getBoundingClientRect().width;
+                        }
+                        else {
+                          elmLeft = $elm[0].getBoundingClientRect().left;
+                        }
                         movingElementStyles.left = (elmLeft - gridLeft) + 'px';
                         var gridRight = $scope.grid.element[0].getBoundingClientRect().right;
                         var elmRight = $elm[0].getBoundingClientRect().right;


### PR DESCRIPTION
On Safari, the handle to move columns has an offset, which increases the more you have horizontally scrolled (so not really visible when the table has not many columns)

The changes proposed compute differently the initial position of the handle for Safari only.