### PR TITLE
introduce directive property for column filter definition

### DIFF
--- a/src/js/core/directives/ui-grid-filter.js
+++ b/src/js/core/directives/ui-grid-filter.js
@@ -1,0 +1,18 @@
+(function(){
+  'use strict';
+
+  angular.module('ui.grid').directive('uiGridFilter', function ($compile, $templateCache) {
+
+    return {
+      compile: function() {
+        return {
+          pre: function ($scope, $elm, $attrs) {
+            var template = $scope.colFilter.filterTemplate || $scope.col.filterTemplate;
+
+            $elm.append($compile(template)($scope));
+          }
+        };
+      }
+    };
+  });
+})();

--- a/src/js/core/services/gridClassFactory.js
+++ b/src/js/core/services/gridClassFactory.js
@@ -160,12 +160,16 @@
           }
 
           var
-            templates = ['HeaderCell', 'Cell', 'FooterCell'],
+            templates = ['HeaderCell', 'Cell', 'FooterCell', 'Filter'],
             templateGetPromises = [];
 
           for (var i = 0; i < templates.length; ++i) {
             preprocessTemplate(templates[i], colDef, col);
           }
+
+          angular.forEach(colDef.filters, function(filter, i) {
+            preprocessTemplate('Filter', filter, col.filters[i]);
+          });
 
           // Create a promise for the compiled element function
           col.compiledElementFnDefer = $q.defer();

--- a/src/templates/ui-grid/uiGridFilter.html
+++ b/src/templates/ui-grid/uiGridFilter.html
@@ -1,0 +1,5 @@
+<input type="text" class="ui-grid-filter-input" ng-model="colFilter.term" ng-attr-placeholder="{{colFilter.placeholder || ''}}" />
+
+<div class="ui-grid-filter-button" ng-click="colFilter.term = null">
+  <i class="ui-grid-icon-cancel" ng-show="!!colFilter.term">&nbsp;</i> <!-- use !! because angular interprets 'f' as false -->
+</div>

--- a/src/templates/ui-grid/uiGridHeaderCell.html
+++ b/src/templates/ui-grid/uiGridHeaderCell.html
@@ -12,11 +12,6 @@
     <i class="ui-grid-icon-angle-down">&nbsp;</i>
   </div>
 
-  <div ng-if="filterable" class="ui-grid-filter-container" ng-repeat="colFilter in col.filters">
-    <input type="text" class="ui-grid-filter-input" ng-model="colFilter.term" ng-attr-placeholder="{{colFilter.placeholder || ''}}" />
-
-    <div class="ui-grid-filter-button" ng-click="colFilter.term = null">
-      <i class="ui-grid-icon-cancel" ng-show="!!colFilter.term">&nbsp;</i> <!-- use !! because angular interprets 'f' as false -->
-    </div>
+  <div ng-if="filterable" class="ui-grid-filter-container" ng-repeat="colFilter in col.filters" ui-grid-filter>
   </div>
 </div>

--- a/test/unit/core/services/GridClassFactory.spec.js
+++ b/test/unit/core/services/GridClassFactory.spec.js
@@ -115,7 +115,20 @@ describe('gridClassFactory', function() {
       expect(testSetup.col.cellTemplate).toEqual('<div>a sample cell template with custom_filters</div>');      
       expect(testSetup.col.footerCellTemplate).toEqual('<div>a sample footer template with custom_filters</div>');
     });
-    
+
+    describe('custom column filter templates', function() {
+      
+      it('filters can have custom templates', function() {
+        testSetup.colDef.filters = [{filterTemplate: 'myownfiltertemplate/0001'}];
+        testSetup.col.filters = [{}];
+
+        testSetup.$templateCache.put('myownfiltertemplate/0001', '<div>SEARCH_FOR_ME</div>');
+
+        gridClassFactory.defaultColumnBuilder( testSetup.colDef, testSetup.col, testSetup.gridOptions );
+
+        expect(testSetup.col.filters[0].providedFilterTemplate).toEqual('myownfiltertemplate/0001');
+      });
+    });
   });
 
 });


### PR DESCRIPTION
This should solve #2796 by adding a 'directive:' property to the filter definition, e.g.:
```javascript
columnDefs: [{
  name: 'eventData',
  filter: {
    directive: 'my-own-datepicker'
  }}]
```

If directive is defined than this directive is used to render the filter instead of the default text input field.

So we propose:
a) to add the above directive configuration property
b) to do a 'deep watch' on the 'term' property and allowing arbitrary JavaScript objects on the the 'term' property. This of course only makes sense with external filtering.
c) to allow custom filtering directives to add data to the filter definition. In our case we would like to add a 'type' property that is than also send to the server for server side filtering. Thus the server code nows what filter directive was used and how to interpret the term property.
d) to share the scope with the custom filter directive to make c) possible and it didn't work without that for us.

This pull request is only meant as a proof-of-concept and we'd be glad to also provide documentation and tests if you accept the idea.

Thank you.

