### PR TITLE
Feat(grouping): alpha release of grouping feature

### DIFF
--- a/grunt/aliases.js
+++ b/grunt/aliases.js
@@ -10,7 +10,7 @@ module.exports = function (grunt, options) {
     'default': ['before-test', 'test:single', 'after-test'],
     
     // Build with no testing
-    'build': ['ngtemplates', 'concat', 'uglify', 'newer:fontello', 'less', 'ngdocs', 'copy'],
+    'build': ['ngtemplates', 'concat', 'uglify', 'fontello', 'less', 'ngdocs', 'copy'],
 
     // Auto-test tasks for development
     'autotest:unit': ['karmangular:start'],

--- a/misc/site/data/500_complex.json
+++ b/misc/site/data/500_complex.json
@@ -985,7 +985,7 @@
         "isActive": true,
         "balance": "$2,313.00",
         "picture": "http://placehold.it/32x32",
-        "age": 23,
+        "age": 49,
         "name": "Ramos Garner",
         "gender": "male",
         "company": "Kyaguru",

--- a/misc/tutorial/209_grouping.ngdoc
+++ b/misc/tutorial/209_grouping.ngdoc
@@ -1,0 +1,111 @@
+@ngdoc overview
+@name Tutorial: 209 Grouping
+@description The grouping feature allows you to group rows together based on similar
+values in specific columns, providing an effect similar in some ways to an Excel pivot table.
+
+Grouping leverages the sort functionality, and has some impacts on sorting.  A column(s) that
+is marked as being grouped is always the first column(s) in the sort list.  The actual sort order,
+and therefore group order, is based on the sorting that has been set for that column, so it can
+leverage custom sort functions and external sorting.
+
+Any grouped column has 'suppressRemoveSort' set, when a column is ungrouped then `suppressRemoveSort`
+is returned to the value in the columnDef.
+
+Optionally (and by default) grouped columns are moved to the front of the grid, which provides a more
+visually pleasing effect.  This isn't done with pinning, so as to not create a dependency on pinning, 
+but by moving the columns themselves. 
+
+Aggregation is permitted on any column that isn't being grouped by, so you can obtain counts, sums,
+max or min for any of the non-grouped columns.
+
+Grouping and aggregation should work cleanly with filtering - it should group and aggregate only the 
+filtered rows.
+
+Grouping is still alpha, and under development, however it is included in the distribution files
+to allow people to start using it.  Notable outstandings are:
+
+- does not permit columns that are based on functions or complex objects.  The groupHeader rows create
+  a fake row.entity, and then set the appropriate fields in that entity.  This doesn't work well with 
+  complex column definitions at present
+- doesn't work well with edit yet.  Edit needs to notice that the row is of type internal, and not 
+  attempt to edit it
+- the adding of menu items has a repetitive smell about it, refactor to be cleaner.  Maybe need a remove aggregation item too
+- notify data change capability is needed for when people programmatically change the grouping  
+- aggregation doesn't check data types, it's quite naive.  Things like dates are likely to break somehow
+- some more unit testing
+- enhancement: allow a limit on number of columns grouped
+- enhancement: add average to the aggregations (requires more data to be stored - count, total, value, and they need to 
+  all be initialised) 
+- consideration of RTL - not sure whether the indent/outdent should get reversed?
+
+Options to watch out for include:
+
+- `groupingIndent`: the expand buttons are indented by a number of pixels (default 10) as the grouping
+  level gets deeper.  Larger values look nicer, but mean that you probably need to make your groupHeader
+  wider if you're allowing deep grouping
+- `groupingRowHeaderWidth`: the width of the grouping row header, important as above 
+   
+
+@example
+In this example we group by the state column then the gender column, and we count the names (a proxy for 
+counting the number of rows), and we find the max age for each grouping.
+
+<example module="app">
+  <file name="app.js">
+    var app = angular.module('app', ['ngAnimate', 'ngTouch', 'ui.grid', 'ui.grid.grouping', 'ui.grid.pinning' ]);
+
+    app.controller('MainCtrl', ['$scope', '$http', '$interval', 'uiGridGroupingConstants', function ($scope, $http, $interval, uiGridGroupingConstants ) {
+      $scope.gridOptions = {
+        enableFiltering: true,
+        columnDefs: [
+          { name: 'state', grouping: { groupPriority: 1 }, sort: { direction: 'desc' }, width: '25%' },
+          { name: 'gender', grouping: { groupPriority: 2 }, sort: { direction: 'asc' }, width: '20%' },
+          { name: 'name', grouping: { aggregation: uiGridGroupingConstants.aggregation.COUNT }, width: '30%' },
+          { name: 'age', grouping: { aggregation: uiGridGroupingConstants.aggregation.MAX }, width: '20%' },
+          { name: 'company', width: '25%' },
+          { name: 'balance', width: '20%' }
+        ],
+        onRegisterApi: function( gridApi ) {
+          $scope.gridApi = gridApi;
+        }
+      };
+
+     $http.get('/data/500_complex.json')
+     .success(function(data) {
+       for ( var i = 0; i < data.length; i++ ){
+         data[i].state = data[i].address.state;
+       }
+       $scope.gridOptions.data = data;
+     });
+ 
+      $scope.expandAll = function(){
+        $scope.gridApi.grouping.expandAllRows();
+      };
+      
+      $scope.toggleRow = function( rowNum ){
+        $scope.gridApi.grouping.toggleRowGroupingState($scope.gridApi.grid.renderContainers.body.visibleRowCache[rowNum]);
+      }
+    }]);
+  </file>
+  
+  <file name="index.html">
+    <div ng-controller="MainCtrl">
+      <div id="grid1" ui-grid="gridOptions" ui-grid-grouping ui-grid-pinning class="grid"></div>
+      <button id="expandAll" type="button" class="btn btn-success" ng-click="expandAll()">Expand All</button>
+      <button id="toggleFirstRow" type="button" class="btn btn-success" ng-click="toggleRow(0)">Toggle First Row</button>
+      <button id="toggleSecondRow" type="button" class="btn btn-success" ng-click="toggleRow(1)">Toggle Second Row</button>
+    </div>
+  </file>
+  
+  <file name="main.css">
+    .grid {
+      width: 500px;
+      height: 400px;
+    }
+  </file>
+  <file name="scenario.js">
+    var gridTestUtils = require('../../test/e2e/gridTestUtils.spec.js');
+    describe( '209 grouping', function() {
+    });
+  </file>  
+</example>

--- a/src/features/grouping/js/grouping.js
+++ b/src/features/grouping/js/grouping.js
@@ -1,0 +1,1345 @@
+(function () {
+  'use strict';
+
+  /**
+   * @ngdoc overview
+   * @name ui.grid.grouping
+   * @description
+   *
+   *  # ui.grid.grouping
+   * This module provides grouping of rows based on the data in them, similar
+   * in concept to excel grouping.  You can group multiple columns, resulting in 
+   * nested grouping.
+   * 
+   * In concept this feature is similar to sorting + grid footer/aggregation, it
+   * sorts the data based on the grouped columns, then creates group rows that
+   * reflect a break in the data.  Each of those group rows can have aggregations for
+   * the data within that group.
+   * 
+   * Design information:
+   * -------------------
+   * 
+   * Each column will get new menu items - group by, and aggregate by.  Group by
+   * will cause this column to be sorted (if not already), and will move this column
+   * to the front of the sorted columns (i.e. grouped columns take precedence over
+   * sorted columns).  It will respect the sort order already set if there is one,
+   * and it will allow the sorting logic to change that sort order, it just forces
+   * the column to the front of the sorting.  You can group by multiple columns, the
+   * logic will add this column to the sorting after any already grouped columns.
+   * 
+   * Once a grouping is defined, grouping logic is added to the rowsProcessors.  This
+   * will process the rows, identifying a break in the data value, and inserting a grouping row.
+   * Grouping rows have specific attributes on them:
+   * 
+   *  - internalRow = true: tells us that this isn't a real row, so we can ignore it 
+   *    from any processing that it looking at core data rows.  This is used by the core
+   *    logic (or will be one day), as it's not grouping specific
+   *  - groupHeader = true: tells us this is a groupHeader.  This is used by the grouping logic
+   *    to know if this is a groupHeader row or not
+   *  - groupLevel = num: first level is 0, tells us what level of grouping the row relates to
+   *  - expandedState = object: pointer to the node in the grid.grouping.rowExpandedStates that refers
+   *    to this row, allowing us to manipulate the state
+   * 
+   * Since the logic is baked into the rowsProcessors, it should get triggered whenever
+   * row order or filtering or anything like that is changed.  We recall the expanded state
+   * across invocations of the rowsProcessors by putting it into the grid.grouping.rowExpandedStates hash.
+   * 
+   * By default rows are collapsed, which means all data rows have their visible property
+   * set to false, and only level 0 group rows are set to visible.
+   * 
+   * We rely on the rowsProcessors to do the actual expanding and collapsing, so we set the flags we want into
+   * grid.grouping.rowExpandedStates, then call refresh.  This is because we can't easily change the visible
+   * row cache without calling the processors, and once we've built the logic into the rowProcessors we may as
+   * well use it all the time.
+   *  
+   * Note that we don't really manipulate row visibility directly - we set the reasonInvisible.grouping
+   * flag, and then ask the row to calculate it's own visibility.  This means we should work fine with 
+   * filtering - filtered rows wouldn't get included in our grouping logic.
+   * 
+   * <br/>
+   * <br/>
+   *
+   * <div doc-module-components="ui.grid.grouping"></div>
+   */
+
+  var module = angular.module('ui.grid.grouping', ['ui.grid']);
+
+  /**
+   *  @ngdoc object
+   *  @name ui.grid.grouping.constant:uiGridGroupingConstants
+   *
+   *  @description constants available in grouping module
+   * 
+   *  Of particular note are:
+   *  ```
+   *    uiGridGroupingConstants.aggregation.COUNT
+   *    uiGridGroupingConstants.aggregation.SUM
+   *    uiGridGroupingConstants.aggregation.MAX
+   *    uiGridGroupingConstants.aggregation.MIN
+   *  ```
+   */
+  module.constant('uiGridGroupingConstants', {
+    featureName: "grouping",
+    groupingRowHeaderColName: 'groupingRowHeaderCol',
+    EXPANDED: 'expanded',
+    COLLAPSED: 'collapsed',
+    aggregation: {
+      COUNT: 'count',
+      SUM: 'sum',
+      MAX: 'max',
+      MIN: 'min'
+    }
+  });
+
+  /**
+   *  @ngdoc service
+   *  @name ui.grid.grouping.service:uiGridGroupingService
+   *
+   *  @description Services for grouping features
+   */
+  module.service('uiGridGroupingService', ['$q', 'uiGridGroupingConstants', 'gridUtil', 'GridRow', 'gridClassFactory', 'i18nService', 'uiGridConstants',
+    function ($q, uiGridGroupingConstants, gridUtil, GridRow, gridClassFactory, i18nService, uiGridConstants) {
+
+      var service = {
+
+        initializeGrid: function (grid, $scope) {
+
+          //add feature namespace and any properties to grid for needed
+          /**
+           *  @ngdoc object
+           *  @name ui.grid.grouping.grid:grouping
+           *
+           *  @description Grid properties and functions added for grouping
+           */
+          grid.grouping = {};
+
+          /**
+           *  @ngdoc property
+           *  @propertyOf ui.grid.grouping.grid:grouping
+           *  @name numberLevels
+           *
+           *  @description Total number of grouping levels currently turned on (i.e. number
+           *   of grouped columns)
+           */
+          grid.grouping.numberLevels = 0;
+
+          /**
+           *  @ngdoc property
+           *  @propertyOf ui.grid.grouping.grid:grouping
+           *  @name expandAll
+           *
+           *  @description Whether or not the expandAll box is selected
+           */
+          grid.grouping.expandAll = false;
+          
+          /**
+           *  @ngdoc property
+           *  @propertyOf ui.grid.grouping.grid:grouping
+           *  @name rowExpandedStates
+           *
+           *  @description Hash that holds all the expanded states based on the group
+           *  columns.  So if I've grouped on two columns - gender and age - then I might
+           *  expect this object to contain:
+           *  ```
+           *    {
+           *      male: {
+           *        state: 'expanded',
+           *        10: { state: 'expanded' },
+           *        11: { state: 'collapsed' },
+           *        19: { state: 'expanded' },
+           *        20: { state: 'collapsed' }
+           *      },
+           *      female: {
+           *        state: 'collapsed',
+           *        15: { state: 'expanded' },
+           *        18: { state: 'collapsed' },
+           *        38: { state: 'expanded' }
+           *      }
+           *    }
+           *  ```
+           *  Missing values are false - meaning they aren't expanded.
+           * 
+           *  This is used because the rowProcessors run every time the grid is refreshed, so
+           *  we'd lose the expanded state every time the grid was refreshed.  This instead gives
+           *  us a reliable lookup that persists across rowProcessors.
+           *  
+           *  The hash gets reset when the group conditions change.
+           * 
+           */
+          grid.grouping.rowExpandedStates = {};
+
+          service.defaultGridOptions(grid.options);
+          
+          grid.registerRowsProcessor(service.groupRows);
+          
+          /**
+           *  @ngdoc object
+           *  @name ui.grid.grouping.api:PublicApi
+           *
+           *  @description Public Api for grouping feature
+           */
+          var publicApi = {
+            events: {
+              grouping: {
+              }
+            },
+            methods: {
+              grouping: {
+                /**
+                 * @ngdoc function
+                 * @name expandAllRows
+                 * @methodOf  ui.grid.grouping.api:PublicApi
+                 * @description Expands all grouped rows
+                 */
+                expandAllRows: function () {
+                  service.expandAllRows(grid);
+                },
+                
+                /**
+                 * @ngdoc function
+                 * @name collapseAllRows
+                 * @methodOf  ui.grid.grouping.api:PublicApi
+                 * @description collapse all grouped rows
+                 */
+                collapseAllRows: function () {
+                  service.collapseAllRows(grid);
+                },
+                
+                /**
+                 * @ngdoc function
+                 * @name toggleRowGroupingState
+                 * @methodOf  ui.grid.grouping.api:PublicApi
+                 * @description  call expand if the row is collapsed, collapse if it is expanded
+                 * @param {gridRow} row the row you wish to toggle
+                 */
+                toggleRowGroupingState: function (row) {
+                  service.toggleRowGroupingState(grid, row);
+                },
+                
+                /**
+                 * @ngdoc function
+                 * @name expandRow
+                 * @methodOf  ui.grid.grouping.api:PublicApi
+                 * @description expand the immediate children of the specified row
+                 * @param {gridRow} row the row you wish to expand
+                 */
+                expandRow: function (row) {
+                  service.expandRow(grid, row);
+                },
+                
+                /**
+                 * @ngdoc function
+                 * @name expandRowChildren
+                 * @methodOf  ui.grid.grouping.api:PublicApi
+                 * @description expand all children of the specified row
+                 * @param {gridRow} row the row you wish to expand
+                 */
+                expandRowChildren: function (row) {
+                  service.expandRowChildren(grid, row);
+                },
+                
+                /**
+                 * @ngdoc function
+                 * @name collapseRow
+                 * @methodOf  ui.grid.grouping.api:PublicApi
+                 * @description collapse all children of the specified row.  When
+                 * you expand the row again, all grandchildren will be collapsed
+                 * @param {gridRow} row the row you wish to expand
+                 */
+                collapseRow: function ( row ) {
+                  service.collapseRow(grid, row);
+                }
+              }
+            }
+          };
+
+          grid.api.registerEventsFromObject(publicApi.events);
+
+          grid.api.registerMethodsFromObject(publicApi.methods);
+          
+          grid.api.core.on.sortChanged( $scope, service.tidyPriorities);
+
+        },
+
+        defaultGridOptions: function (gridOptions) {
+          //default option to true unless it was explicitly set to false
+          /**
+           *  @ngdoc object
+           *  @name ui.grid.grouping.api:GridOptions
+           *
+           *  @description GridOptions for grouping feature, these are available to be
+           *  set using the ui-grid {@link ui.grid.class:GridOptions gridOptions}
+           */
+
+          /**
+           *  @ngdoc object
+           *  @name enableGrouping
+           *  @propertyOf  ui.grid.grouping.api:GridOptions
+           *  @description Enable row grouping for entire grid.
+           *  <br/>Defaults to true
+           */
+          gridOptions.enableGrouping = gridOptions.enableGrouping !== false;
+
+          /**
+           *  @ngdoc object
+           *  @name groupingRowHeaderWidth
+           *  @propertyOf  ui.grid.grouping.api:GridOptions
+           *  @description Width of the grouping header, if your nested grouping is too
+           *  deep you may need to increase this 
+           *  <br/>Defaults to 40
+           */
+          gridOptions.groupingRowHeaderWidth = gridOptions.groupingRowHeaderWidth || 40;
+
+          /**
+           *  @ngdoc object
+           *  @name groupingIndent
+           *  @propertyOf  ui.grid.grouping.api:GridOptions
+           *  @description Number of pixels of indent for the icon at each grouping level, wider indents are visually more pleasing,
+           *  but may result in you having to make the group row header wider
+           *  <br/>Defaults to 10
+           */
+          gridOptions.groupingIndent = gridOptions.groupingIndent || 10;
+        },
+
+
+        /**
+         * @ngdoc function
+         * @name groupingColumnBuilder
+         * @methodOf  ui.grid.grouping.service:uiGridGroupingService
+         * @description Sets the grouping defaults based on the columnDefs
+         * 
+         * @param {object} colDef columnDef we're basing on
+         * @param {GridCol} col the column we're to update
+         * @param {object} gridOptions the options we should use
+         * @returns {promise} promise for the builder - actually we do it all inline so it's immediately resolved
+         */
+        groupingColumnBuilder: function (colDef, col, gridOptions) {
+          /**
+           *  @ngdoc object
+           *  @name ui.grid.grouping.api:ColumnDef
+           *
+           *  @description ColumnDef for grouping feature, these are available to be 
+           *  set using the ui-grid {@link ui.grid.class:GridOptions.columnDef gridOptions.columnDefs}
+           */
+
+          /**
+           *  @ngdoc object
+           *  @name enableGrouping
+           *  @propertyOf  ui.grid.grouping.api:ColumnDef
+           *  @description Enable grouping on this column
+           *  <br/>Defaults to true.
+           */
+          if (colDef.enableGrouping === false){
+            return;
+          }
+
+          /**
+           *  @ngdoc object
+           *  @name grouping
+           *  @propertyOf  ui.grid.grouping.api:ColumnDef
+           *  @description Set the grouping for a column.  Format is:
+           *  ```
+           *    {
+           *      groupPriority: <number, starts at 0, if less than 0 or undefined then we're aggregating in this column>,
+           *      aggregation: <one of uiGridGroupingConstants.aggregation.XXXX>
+           *    }
+           *  ```
+           *  We group in the priority order given, this will also put these columns to the high order of the sort irrespective
+           *  of the sort priority given them.  If there is no sort defined then we sort ascending, if there is a sort defined then
+           *  we use that sort.
+           * 
+           *  If the groupPriority is undefined or less than 0, then we expect to be aggregating, and we look at the aggregation
+           *  types to determine what sort of aggregation we can do.  Values are in the constants file, but include SUM, COUNT, MAX, MIN
+           * 
+           *  groupPriorities should generally be sequential, if they're not then the next time getGrouping is called we'll renumber them
+           *  to be sequential.
+           *  <br/>Defaults to undefined.
+           */
+
+          if ( typeof(col.grouping) === 'undefined' && typeof(colDef.grouping) !== 'undefined') {
+            col.grouping = angular.copy(colDef.grouping);
+          } else if (typeof(col.grouping) === 'undefined'){
+            col.grouping = {};
+          }
+          
+          if (typeof(col.grouping) !== 'undefined' && typeof(col.grouping.groupPriority) !== undefined && col.grouping.groupPriority >= 0){
+            col.suppressRemoveSort = true;
+          } 
+          
+          var groupColumn = {
+            name: 'ui.grid.grouping.group',
+            title: i18nService.get().grouping.group,
+            icon: 'ui-grid-icon-indent-right',
+            shown: function () {
+              return typeof(this.context.col.grouping) === 'undefined' || 
+                     typeof(this.context.col.grouping.groupPriority) === 'undefined' ||
+                     this.context.col.grouping.groupPriority < 0;
+            },
+            action: function () {
+              service.groupColumn( this.context.col.grid, this.context.col );
+            }
+          };
+
+          var ungroupColumn = {
+            name: 'ui.grid.grouping.ungroup',
+            title: i18nService.get().grouping.ungroup,
+            icon: 'ui-grid-icon-indent-left',
+            shown: function () {
+              return typeof(this.context.col.grouping) !== 'undefined' && 
+                     typeof(this.context.col.grouping.groupPriority) !== 'undefined' &&
+                     this.context.col.grouping.groupPriority >= 0;
+            },
+            action: function () {
+              service.ungroupColumn( this.context.col.grid, this.context.col );
+            }
+          };
+          
+          var aggregateSum = {
+            name: 'ui.grid.grouping.aggregateSum',
+            title: i18nService.get().grouping.aggregate_sum,
+            shown: function () {
+              return typeof(this.context.col.grouping) === 'undefined' || 
+                     typeof(this.context.col.grouping.aggregation) === 'undefined' ||
+                     this.context.col.grouping.aggregation !== uiGridGroupingConstants.aggregation.SUM;
+            },
+            action: function () {
+              service.aggregateColumn( this.context.col.grid, this.context.col, uiGridGroupingConstants.aggregation.SUM);
+            }
+          };
+          
+          var aggregateCount = {
+            name: 'ui.grid.grouping.aggregateCount',
+            title: i18nService.get().grouping.aggregate_count,
+            shown: function () {
+              return typeof(this.context.col.grouping) === 'undefined' || 
+                     typeof(this.context.col.grouping.aggregation) === 'undefined' ||
+                     this.context.col.grouping.aggregation !== uiGridGroupingConstants.aggregation.COUNT;
+            },
+            action: function () {
+              service.aggregateColumn( this.context.col.grid, this.context.col, uiGridGroupingConstants.aggregation.COUNT);
+            }
+          };
+
+          var aggregateMax = {
+            name: 'ui.grid.grouping.aggregateMax',
+            title: i18nService.get().grouping.aggregate_max,
+            shown: function () {
+              return typeof(this.context.col.grouping) === 'undefined' || 
+                     typeof(this.context.col.grouping.aggregation) === 'undefined' ||
+                     this.context.col.grouping.aggregation !== uiGridGroupingConstants.aggregation.MAX;
+            },
+            action: function () {
+              service.aggregateColumn( this.context.col.grid, this.context.col, uiGridGroupingConstants.aggregation.MAX);
+            }
+          };
+
+          var aggregateMin = {
+            name: 'ui.grid.grouping.aggregateMin',
+            title: i18nService.get().grouping.aggregate_min,
+            shown: function () {
+              return typeof(this.context.col.grouping) === 'undefined' || 
+                     typeof(this.context.col.grouping.aggregation) === 'undefined' ||
+                     this.context.col.grouping.aggregation !== uiGridGroupingConstants.aggregation.MIN;
+            },
+            action: function () {
+              service.aggregateColumn( this.context.col.grid, this.context.col, uiGridGroupingConstants.aggregation.MIN);
+            }
+          };
+
+          var aggregateRemove = {
+            name: 'ui.grid.grouping.aggregateRemove',
+            title: i18nService.get().grouping.aggregate_remove,
+            shown: function () {
+              return typeof(this.context.col.grouping) !== 'undefined' && 
+                     typeof(this.context.col.grouping.aggregation) !== 'undefined' &&
+                     this.context.col.grouping.aggregation !== null;
+            },
+            action: function () {
+              service.aggregateColumn( this.context.col.grid, this.context.col, null);
+            }
+          };
+
+          if (!gridUtil.arrayContainsObjectWithProperty(col.menuItems, 'name', 'ui.grid.grouping.group')) {
+            col.menuItems.push(groupColumn);
+          }
+
+          if (!gridUtil.arrayContainsObjectWithProperty(col.menuItems, 'name', 'ui.grid.grouping.ungroup')) {
+            col.menuItems.push(ungroupColumn);
+          }
+          
+          if (!gridUtil.arrayContainsObjectWithProperty(col.menuItems, 'name', 'ui.grid.grouping.aggregateSum')) {
+            col.menuItems.push(aggregateSum);
+          }
+          
+          if (!gridUtil.arrayContainsObjectWithProperty(col.menuItems, 'name', 'ui.grid.grouping.aggregateCount')) {
+            col.menuItems.push(aggregateCount);
+          }
+          
+          if (!gridUtil.arrayContainsObjectWithProperty(col.menuItems, 'name', 'ui.grid.grouping.aggregateMax')) {
+            col.menuItems.push(aggregateMax);
+          }
+          
+          if (!gridUtil.arrayContainsObjectWithProperty(col.menuItems, 'name', 'ui.grid.grouping.aggregateMin')) {
+            col.menuItems.push(aggregateMin);
+          }
+
+          if (!gridUtil.arrayContainsObjectWithProperty(col.menuItems, 'name', 'ui.grid.grouping.aggregateRemove')) {
+            col.menuItems.push(aggregateRemove);
+          }
+          
+        },
+        
+        
+        /**
+         * @ngdoc function
+         * @name groupColumn
+         * @methodOf  ui.grid.grouping.service:uiGridGroupingService
+         * @description Adds this column to the existing grouping, at the end of the priority order.
+         * If the column doesn't have a sort, adds one, by default ASC
+         * 
+         * If the option `groupMoveColumns` hasn't been set to false, moves the column to the left
+         * to make things look tidier.
+         * 
+         * @param {Grid} grid grid object
+         * @param {GridCol} column the column we want to group
+         */
+        groupColumn: function( grid, column){
+          if ( typeof(column.grouping) === 'undefined' ){
+            column.grouping = {};
+          }
+          
+          // set the group priority to the next number in the hierarchy
+          var existingGrouping = service.getGrouping( grid );
+          column.grouping.groupPriority = existingGrouping.grouping.length;
+          
+          // add sort if not present
+          if ( !column.sort ){
+            column.sort = { direction: uiGridConstants.ASC };
+          } else if ( typeof(column.sort.direction) === 'undefined' || column.sort.direction === null ){
+            column.sort.direction = uiGridConstants.ASC;
+          }
+          
+          service.tidyPriorities( grid );
+          service.moveGroupColumns( grid );
+          
+          grid.queueGridRefresh();
+        },
+
+
+        /**
+         * @ngdoc function
+         * @name ungroupColumn
+         * @methodOf  ui.grid.grouping.service:uiGridGroupingService
+         * @description Removes the groupPriority from this column.  If the
+         * column was previously aggregated the aggregation will come back. 
+         * The sort will remain.  
+         * 
+         * This column will move to the right of any other group columns.
+         * 
+         * @param {Grid} grid grid object
+         * @param {GridCol} column the column we want to ungroup
+         */
+        ungroupColumn: function( grid, column){
+          if ( typeof(column.grouping) === 'undefined' ){
+            return;
+          }
+          
+          delete column.grouping.groupPriority;
+          
+          service.tidyPriorities( grid );
+          service.moveGroupColumns( grid );
+          
+          grid.queueGridRefresh();
+        },
+        
+
+        /**
+         * @ngdoc function
+         * @name aggregateColumn
+         * @methodOf  ui.grid.grouping.service:uiGridGroupingService
+         * @description Sets the aggregation type on a column, if the 
+         * column is currently grouped then it removes the grouping first.
+         * 
+         * @param {Grid} grid grid object
+         * @param {GridCol} column the column we want to aggregate
+         * @param {string} aggregationType one of the recognised types
+         * from uiGridGroupingConstants
+         */
+        aggregateColumn: function( grid, column, aggregationType){
+          if (typeof(column.grouping) === 'undefined') {
+            column.grouping = {};
+          }
+          
+          if (typeof(column.grouping.groupPriority) !== 'undefined' && column.grouping.groupPriority >= 0){
+            service.ungroupColumn( grid, column );
+          }
+          
+          column.grouping.aggregation = aggregationType;
+          
+          grid.queueGridRefresh();
+        },
+        
+        
+        /**
+         * @ngdoc function
+         * @name tidyPriorities
+         * @methodOf  ui.grid.grouping.service:uiGridGroupingService
+         * @description Renumbers groupPriority and sortPriority such that
+         * groupPriority is contiguous, and sortPriority either matches
+         * groupPriority (for group columns), and otherwise is contiguous and 
+         * higher than groupPriority. 
+         * 
+         * @param {Grid} grid grid object
+         */
+        tidyPriorities: function( grid ){
+          var groupArray = [];
+          var sortArray = [];
+          
+          angular.forEach(grid.columns, function(column, index){
+            if ( typeof(column.grouping) !== 'undefined' && typeof(column.grouping.groupPriority) !== 'undefined' && column.grouping.groupPriority >= 0){
+              groupArray.push(column);
+            } else if ( typeof(column.sort) !== 'undefined' && typeof(column.sort.priority) !== 'undefined' && column.sort.priority >= 0){
+              sortArray.push(column);
+            }
+          });
+          
+          groupArray.sort(function(a, b){ return a.grouping.groupPriority - b.grouping.groupPriority; });
+          angular.forEach(groupArray, function(column, index){
+            column.grouping.groupPriority = index;
+            column.suppressRemoveSort = true;
+            if ( typeof(column.sort) === 'undefined'){
+              column.sort = {};
+            }
+            column.sort.priority = index;
+          });
+
+          var i = groupArray.length;
+          sortArray.sort(function(a, b){ return a.sort.priority - b.sort.priority; });
+          angular.forEach(sortArray, function(column, index){
+            column.sort.priority = i;
+            column.suppressRemoveSort = column.colDef.suppressRemoveSort;
+            i++;
+          });
+        },
+        
+        
+        /**
+         * @ngdoc function
+         * @name moveGroupColumns
+         * @methodOf  ui.grid.grouping.service:uiGridGroupingService
+         * @description Moves the column order so that the grouped columns are lined up
+         * to the left (well, unless you're RTL, then it's the right).  Doesn't change
+         * the columnDefs, just the columns array.  (check move columns that this is how it works)
+         * 
+         * All other columns retain their relative position, after the group columns 
+         * 
+         * Does nothing if the option `moveGroupColumns` is set to false.
+         * 
+         * @param {Grid} grid grid object
+         */
+        moveGroupColumns: function( grid ){
+          if ( grid.options.moveGroupColumns === false){
+            return;
+          }
+          
+          grid.columns.sort(function(a, b){
+            var a_group, b_group;
+            if ( typeof(a.grouping) === 'undefined' || typeof(a.grouping.groupPriority) === 'undefined' || a.grouping.groupPriority < 0){
+              a_group = null;
+            } else {
+              a_group = a.grouping.groupPriority;
+            }
+
+            if ( typeof(b.grouping) === 'undefined' || typeof(b.grouping.groupPriority) === 'undefined' || b.grouping.groupPriority < 0){
+              b_group = null;
+            } else {
+              b_group = b.grouping.groupPriority;
+            }
+            
+            // groups get sorted to the top
+            if ( a_group !== null && b_group === null) { return -1; }
+            if ( b_group !== null && a_group === null) { return 1; }
+            if ( a_group !== null && b_group !== null) {return a_group - b_group; }
+          });
+          grid.api.core.notifyDataChange( uiGridConstants.dataChange.COLUMN );
+        },
+
+
+        /**
+         * @ngdoc function
+         * @name expandAllRows
+         * @methodOf  ui.grid.grouping.service:uiGridGroupingService
+         * @description Makes each row of the grid visible (from a grouping perspective,
+         * they may still be invisible for other reasons)
+         * 
+         * @param {Grid} grid grid object
+         */
+        expandAllRows: function (grid) {
+          service.setAllNodes( grid.grouping.rowExpandedStates, uiGridGroupingConstants.EXPANDED );
+          grid.queueGridRefresh();
+        },
+ 
+        
+        /**
+         * @ngdoc function
+         * @name collapseAllRows
+         * @methodOf  ui.grid.grouping.service:uiGridGroupingService
+         * @description Makes each row of the grid invisible (from a grouping perspective)
+         * 
+         * @param {Grid} grid grid object
+         */
+        collapseAllRows: function (grid) {
+          service.setAllNodes( grid.grouping.rowExpandedStates, uiGridGroupingConstants.COLLAPSED );
+          grid.queueGridRefresh();
+        },
+
+
+        /**
+         * @ngdoc function
+         * @name setAllNodes
+         * @methodOf  ui.grid.grouping.service:uiGridGroupingService
+         * @description Works through a subset of grid.grouping.rowExpandedStates, setting
+         * all child nodes (and their descendents) of the provided node to the given state.
+         * 
+         * Calls itself recursively on all nodes so as to achieve this.
+         * 
+         * @param {object} expandedStatesSubset the portion of the tree that we want to update
+         */
+        setAllNodes: function (expandedStatesSubset, targetState) {
+          // set this node
+          expandedStatesSubset.state = targetState;
+          
+          // set all child nodes
+          angular.forEach(expandedStatesSubset, function( childNode, key){
+            if (key !== 'state'){
+              service.setAllNodes(childNode, targetState);
+            }
+          });
+        },
+
+        
+        /**
+         * @ngdoc function
+         * @name toggleRowGroupingState
+         * @methodOf  ui.grid.grouping.service:uiGridGroupingService
+         * @description Toggles the expand or collapse state of this grouped row.
+         * If the row isn't a groupHeader, does nothing.
+         * 
+         * @param {Grid} grid grid object
+         * @param {GridRow} row the row we want to toggle
+         */
+        toggleRowGroupingState: function ( grid, row ){
+          if (!row.groupHeader){
+            return;
+          }
+          
+          if (row.expandedState.state === uiGridGroupingConstants.EXPANDED){
+            row.expandedState.state = uiGridGroupingConstants.COLLAPSED;
+          } else {
+            row.expandedState.state = uiGridGroupingConstants.EXPANDED;
+          }
+          
+          grid.queueGridRefresh();
+        },
+        
+
+        /**
+         * @ngdoc function
+         * @name expandRow
+         * @methodOf  ui.grid.grouping.service:uiGridGroupingService
+         * @description Expands this specific row, showing only immediate children.
+         * 
+         * If this row isn't a groupHeader, we do nothing 
+         * 
+         * @param {Grid} grid grid object
+         * @param {GridRow} row the row we want to expand
+         */
+        expandRow: function ( grid, row ){
+          if (!row.groupHeader){
+            return;
+          }
+          
+          row.expandedState.state = uiGridGroupingConstants.EXPANDED;
+          grid.queueGridRefresh();
+        },
+        
+
+        /**
+         * @ngdoc function
+         * @name expandRowChildren
+         * @methodOf  ui.grid.grouping.service:uiGridGroupingService
+         * @description Expands this specific row, showing all children.
+         * 
+         * If this row isn't a groupHeader, we do nothing 
+         * 
+         * @param {Grid} grid grid object
+         * @param {GridRow} row the row we want to expand
+         */
+        expandRowChildren: function ( grid, row ){
+          if (!row.groupHeader){
+            return;
+          }
+          
+          service.setAllNodes(row.expandedState, uiGridGroupingConstants.COLLAPSED);
+          grid.queueGridRefresh();
+        },
+        
+
+       /**
+         * @ngdoc function
+         * @name collapseRow
+         * @methodOf  ui.grid.grouping.service:uiGridGroupingService
+         * @description Collapses this specific row
+         *
+         * @param {Grid} grid grid object
+         * @param {GridRow} row the row we want to collapse
+         */
+        collapseRow: function( grid, row ){
+          if (!row.groupHeader){
+            return;
+          }
+
+          row.expandedState.state = uiGridGroupingConstants.COLLAPSED;
+          grid.queueGridRefresh();
+        },
+        
+        
+       /**
+         * @ngdoc function
+         * @name collapseRowChildren
+         * @methodOf  ui.grid.grouping.service:uiGridGroupingService
+         * @description Collapses this specific row and all children
+         *
+         * @param {Grid} grid grid object
+         * @param {GridRow} row the row we want to collapse
+         */
+        collapseRowChildren: function( grid, row ){
+          if (!row.groupHeader){
+            return;
+          }
+
+          service.setAllNodes(row.expandedState, uiGridGroupingConstants.COLLAPSED);
+          grid.queueGridRefresh();
+        },
+
+        
+       /**
+         * @ngdoc function
+         * @name groupRows
+         * @methodOf  ui.grid.grouping.service:uiGridGroupingService
+         * @description The rowProcessor that creates the groupHeaders (i.e. does
+         * the actual grouping).
+         * 
+         * Assumes it is always called after the sorting processor (TODO: how do we prove that?)
+         * 
+         * Processes all the rows in order, inserting a groupHeader row whenever there is a change
+         * in value of a grouped row, the groupHeader will also cause an update to (or insertion into) the
+         * grid.grouping.rowExpandedStates hash, and a reference to that entry (including it's sub-tree) to be held 
+         * on the gridRow itself in row.expandedState.
+         * 
+         * Aggregates any configured row values whilst it goes, and updates those aggregations into
+         * the previously created groupHeader upon the break in value (aggregations are maintained at each level
+         * of grouping)
+         * 
+         * Uses the `grid.grouping.rowExpandedStates` to decide which rows are visible, the rule is that once any parent
+         * node is collapsed, all nodes below that will be invisible.
+         * 
+         * As it processes it maintains a `groupingProcessingState` array. This records, for each level of grouping we're
+         * working with, the following information:
+         * ```
+         *   {
+         *     fieldName: name,
+         *     initialised: boolean,
+         *     currentValue: value,
+         *     currentGroupHeader: gridRow,
+         *     runningAggregations 
+         *       field: {type: xxxx, value: 1234},
+         *       field: {type: yyyy, value: 2345)
+         *     }
+         *   }
+         * ```
+         * We look for changes in the currentValue at any of the levels.  Where we find a change we:
+         * 
+         * - write out any aggregations to the currentGroupHeader, and reset them
+         * - create a new groupHeader row in the array
+         * 
+         * If there is no change, we just run the aggregations
+         * 
+         * @param {array} renderableRows the rows we want to process, usually the output from the previous rowProcessor
+         * @returns {array} the updated rows, including our new group rows
+         */
+        groupRows: function( renderableRows ) {
+          if (renderableRows.length === 0){
+            return renderableRows;
+          }
+
+          var grid = this;
+          var groupingProcessingState = service.initialiseProcessingState( grid );
+          
+          // processes each of the fields we are grouping by, checks if the value has changed and inserts a groupHeader, 
+          // otherwise aggregates.  Broken out as shouldn't create functions in a loop.
+          var updateProcessingState = function( groupFieldState, stateIndex ) {
+            if ( typeof(row.entity[groupFieldState.fieldName]) === 'undefined' ){
+              return;
+            }
+            
+            if ( !row.visible ){
+              return;
+            }
+            
+            // look for change of value - and insert a header
+            if ( !groupFieldState.initialised || row.entity[groupFieldState.fieldName] !== groupFieldState.currentValue ){
+              service.insertGroupHeader( grid, renderableRows, i, groupingProcessingState, stateIndex );
+              i++;
+            }
+            service.aggregate( grid, row, groupFieldState );
+          };
+          
+          // use a for loop because it's tolerant of the array length changing whilst we go - we can 
+          // manipulate the iterator when we insert groupHeader rows
+          for (var i = 0; i < renderableRows.length; i++ ){
+            var row = renderableRows[i];
+            
+            angular.forEach(groupingProcessingState, updateProcessingState);
+            
+            service.setVisibility( grid, row, groupingProcessingState );
+          }
+          
+          // write out the last aggregation amounts
+          service.writeOutAggregations( grid, groupingProcessingState, 0);
+
+          
+          return renderableRows;
+        },
+        
+        
+       /**
+         * @ngdoc function
+         * @name initialiseProcessingState
+         * @methodOf  ui.grid.grouping.service:uiGridGroupingService
+         * @description The rowProcessor that creates the groupHeaders (i.e. does
+         * the actual grouping).
+         * 
+         * @param {Grid} grid grid object
+         * @returns {array} an array in the format described in the groupRows method, 
+         * initialised with blank values
+         */
+        initialiseProcessingState: function( grid ){
+          var processingState = [];
+          var columnSettings = service.getGrouping( grid );
+          
+          // get the aggregation config to copy in
+          var aggregations = {};
+          angular.forEach(columnSettings.aggregations, function(aggregation, index){
+            aggregations[aggregation.field] = { type: aggregation.aggregation, value: null };
+          });
+          
+          angular.forEach(columnSettings.grouping, function( groupItem, index){
+            processingState.push({ 
+              fieldName: groupItem.field,
+              initialised: false,
+              currentValue: null,
+              currentGroupHeader: null,
+              runningAggregations: angular.copy(aggregations)
+            });
+          });
+          
+          return processingState;          
+        },
+
+        
+       /**
+         * @ngdoc function
+         * @name getGrouping
+         * @methodOf  ui.grid.grouping.service:uiGridGroupingService
+         * @description Get the grouping settings from the columns.  As a side effect
+         * this always renumbers the grouping starting at 0
+         * @param {Grid} grid grid object
+         * @returns {array} an array of the group fields, in order of priority
+         */
+        getGrouping: function( grid ){
+          var groupArray = [];
+          var aggregateArray = [];
+          
+          // get all the grouping
+          angular.forEach(grid.columns, function(column, columnIndex){
+            if ( column.grouping ){
+              if ( typeof(column.grouping.groupPriority) !== 'undefined' && column.grouping.groupPriority >= 0){
+                groupArray.push({ field: column.field, groupPriority: column.grouping.groupPriority, grouping: column.grouping });  
+              } else if ( column.grouping.aggregation ){
+                aggregateArray.push({ field: column.field, aggregation: column.grouping.aggregation });
+              }
+            }
+          });
+          
+          // sort grouping into priority order
+          groupArray.sort( function(a, b){
+            return a.groupPriority - b.groupPriority;
+          });
+          
+          // renumber the priority in case it was somewhat messed up, then remove the grouping reference
+          angular.forEach( groupArray, function( group, index) {
+            group.grouping.groupPriority = index;
+            group.groupPriority = index;
+            delete group.grouping;
+          }); 
+          
+          return { grouping: groupArray, aggregations: aggregateArray };
+        },
+        
+        
+       /**
+         * @ngdoc function
+         * @name insertGroupHeader
+         * @methodOf  ui.grid.grouping.service:uiGridGroupingService
+         * @description Create a group header row, and link it to the various configuration
+         * items that we use.  Write out any grouping aggregation for this group and groups that are children of this one
+         * @param {Grid} grid grid object
+         * @param {array} renderableRows the rows that we are processing
+         * @param {number} rowIndex the row we were up to processing
+         * @param {array} groupingProcessingState the state we're up to - we update this when we write out
+         * the aggregation
+         * @param {number} stateIndex the processing state item that we were on when we triggered a new group header - 
+         * i.e. the column that we want to create a header for
+         */
+        insertGroupHeader: function( grid, renderableRows, rowIndex, groupingProcessingState, stateIndex ) {
+          // write out aggregations for this column grouping and any child groupings, and reinitialise those states
+          service.writeOutAggregations( grid, groupingProcessingState, stateIndex);
+          
+          var headerRow = new GridRow( {}, null, grid );
+          
+          gridClassFactory.rowTemplateAssigner.call(grid, headerRow);          
+          
+          // set the value that caused the end of a group into the header row and the processing state
+          var fieldName = groupingProcessingState[stateIndex].fieldName;
+
+          // TODO: can't just use entity like this, have to use get cell value, need col for that
+          var newValue = renderableRows[rowIndex].entity[fieldName];
+          headerRow.entity[fieldName] = newValue;
+          headerRow.groupLevel = stateIndex;
+          headerRow.groupHeader = true;
+          headerRow.internalRow = true;
+          groupingProcessingState[stateIndex].initialised = true;
+          groupingProcessingState[stateIndex].currentValue = newValue;
+          groupingProcessingState[stateIndex].currentGroupHeader = headerRow;
+          
+          headerRow.expandedState = service.getExpandedState( grid, groupingProcessingState, stateIndex);
+          service.setVisibility( grid, headerRow, groupingProcessingState );
+          
+          // insert our new header row
+          renderableRows.splice(rowIndex, 0, headerRow);
+        },
+        
+        
+       /**
+         * @ngdoc function
+         * @name writeOutAggregations
+         * @methodOf  ui.grid.grouping.service:uiGridGroupingService
+         * @description Write out the aggregations for the group that has changed, and any children of that group, which 
+         * by definition have changed as well.  Reset the processing state to reflect that all children of the group now
+         * triggered a new group as well
+         * @param {Grid} grid grid object
+         * @param {array} groupingProcessingState the state we're up to - we update this when we write out
+         * the aggregation
+         * @param {number} stateIndex the processing state item that we were on when we triggered a new group header - 
+         * i.e. the column that we want to create a header for
+         */
+        writeOutAggregations: function( grid, groupingProcessingState, stateIndex ) {
+          for (var i = stateIndex; i < groupingProcessingState.length; i++ ){
+            service.writeOutAggregation( grid, groupingProcessingState[i] );
+          }
+        },
+        
+        
+       /**
+         * @ngdoc function
+         * @name writeOutAggregation
+         * @methodOf  ui.grid.grouping.service:uiGridGroupingService
+         * @description Writes a single aggregation to the linked groupingHeader, and clears the processing state
+         * for that group 
+         * @param {Grid} grid grid object
+         * @param {object} processingState the specific group column that we're writing out state for, and resetting
+         * the aggregation
+         */
+        writeOutAggregation: function( grid, processingState ) {
+          if ( processingState.currentGroupHeader ){
+            angular.forEach(processingState.runningAggregations, function( aggregation, fieldName ){
+              // TODO: i18n on aggregation types
+              processingState.currentGroupHeader.entity[fieldName] = i18nService.get().aggregation[aggregation.type] + aggregation.value;
+              aggregation.value = null;
+            });
+          }
+          processingState.currentGroupHeader = null;
+          processingState.currentValue = null;
+          processingState.initialised = false;
+        },
+        
+
+       /**
+         * @ngdoc function
+         * @name getExpandedState
+         * @methodOf  ui.grid.grouping.service:uiGridGroupingService
+         * @description Gets the expanded state reference from the `grid.grouping.rowExpandedStates` for 
+         * the given processingState and state index.  In effect this is finding the entry for a given 
+         * groupingHeader so that we can store a reference to it on the groupHeader, and use it to work
+         * out visibility.
+         * 
+         * @param {Grid} grid grid object
+         * @param {array} groupingProcessingState the state we're currently in (contains the current values
+         * of each of the groups)
+         * @param {number} stateIndex the index of the processing state (i.e. column) that we want the reference for
+         */
+        getExpandedState: function( grid, groupingProcessingState, stateIndex){
+          var currentNode = grid.grouping.rowExpandedStates;
+          
+          for ( var i = 0; i <= stateIndex; i++ ){
+            // if no node for this group value, then create it
+            if ( !currentNode[groupingProcessingState[i].currentValue] ){
+              currentNode[groupingProcessingState[i].currentValue] = { state: uiGridGroupingConstants.COLLAPSED };
+            }
+            currentNode = currentNode[groupingProcessingState[i].currentValue];
+          }
+          
+          return currentNode;
+        },
+        
+        
+       /**
+         * @ngdoc function
+         * @name setVisibility
+         * @methodOf  ui.grid.grouping.service:uiGridGroupingService
+         * @description Determine the visibility of a row based on the processing state, which contains references to the
+         * row headers, and therefore to the relevant rowExpandedStates.
+         * 
+         * @param {Grid} grid grid object
+         * @param {GridRow} row the row we want to set grouping visibility on
+         * @param {array} groupingProcessingState the state we're currently in (contains the current values
+         * of each of the groups)
+         */
+        setVisibility: function( grid, row, groupingProcessingState ){
+          // don't set visibility on an already invisible row
+          if (!row.visible){
+            return;
+          }
+          
+          var visible = true;
+          var groupLevel = typeof(row.groupLevel) !== 'undefined' ? row.groupLevel : groupingProcessingState.length;
+          for (var i = 0; i < groupLevel; i++){
+            if ( groupingProcessingState[i].currentGroupHeader.expandedState.state === uiGridGroupingConstants.COLLAPSED ){
+              visible = false;
+            }
+          }
+          
+          // we're running in a rowProcessor, so default is always visible, we don't need to set it unless we want invisible
+          if ( !visible ){
+            row.setThisRowInvisible( 'grouping', true );
+          }
+        },
+        
+        
+       /**
+         * @ngdoc function
+         * @name aggregate
+         * @methodOf  ui.grid.grouping.service:uiGridGroupingService
+         * @description Accumulate the data from this row onto the aggregation for each processingState (for each level of grouping).
+         * 
+         * @param {Grid} grid grid object
+         * @param {GridRow} row the row we want to set grouping visibility on
+         * @param {object} groupFieldState the processing state for the field/column/group we're currently processing for
+         */
+        aggregate: function( grid, row, groupFieldState ){
+          // TODO: check data types, cast as necessary, all that jazz
+          angular.forEach( groupFieldState.runningAggregations, function( aggregation, fieldName ){
+            if (row.entity[fieldName] ){
+              switch (aggregation.type) {
+                case uiGridGroupingConstants.aggregation.COUNT:
+                  aggregation.value++;
+                  break;
+                case uiGridGroupingConstants.aggregation.SUM:
+                  aggregation.value += row.entity[fieldName];
+                  break;
+                case uiGridGroupingConstants.aggregation.MIN:
+                  if (row.entity[fieldName] < aggregation.value){
+                    aggregation.value = row.entity[fieldName];
+                  }
+                  break;
+                case uiGridGroupingConstants.aggregation.MAX:
+                  if (row.entity[fieldName] > aggregation.value){
+                    aggregation.value = row.entity[fieldName];
+                  }
+                  break;
+              }
+            }
+          });
+        }        
+
+      };
+
+      return service;
+
+    }]);
+
+  /**
+   *  @ngdoc directive
+   *  @name ui.grid.grouping.directive:uiGridGrouping
+   *  @element div
+   *  @restrict A
+   *
+   *  @description Adds grouping features to grid
+   *
+   *  @example
+   <example module="app">
+   <file name="app.js">
+   var app = angular.module('app', ['ui.grid', 'ui.grid.grouping']);
+
+   app.controller('MainCtrl', ['$scope', function ($scope) {
+      $scope.data = [
+        { name: 'Bob', title: 'CEO' },
+            { name: 'Frank', title: 'Lowly Developer' }
+      ];
+
+      $scope.columnDefs = [
+        {name: 'name', enableCellEdit: true},
+        {name: 'title', enableCellEdit: true}
+      ];
+      
+      $scope.gridOptions = { columnDefs: $scope.columnDefs, data: $scope.data };
+    }]);
+   </file>
+   <file name="index.html">
+   <div ng-controller="MainCtrl">
+   <div ui-grid="gridOptions" ui-grid-grouping></div>
+   </div>
+   </file>
+   </example>
+   */
+  module.directive('uiGridGrouping', ['uiGridGroupingConstants', 'uiGridGroupingService', '$templateCache',
+    function (uiGridGroupingConstants, uiGridGroupingService, $templateCache) {
+      return {
+        replace: true,
+        priority: 0,
+        require: '^uiGrid',
+        scope: false,
+        compile: function () {
+          return {
+            pre: function ($scope, $elm, $attrs, uiGridCtrl) {
+              if (uiGridCtrl.grid.options.enableGrouping !== false){
+                uiGridGroupingService.initializeGrid(uiGridCtrl.grid, $scope);
+                var groupingRowHeaderDef = {
+                  name: uiGridGroupingConstants.groupingRowHeaderColName,
+                  displayName: '',
+                  width:  uiGridCtrl.grid.options.groupingRowHeaderWidth,
+                  minWidth: 10,
+                  cellTemplate: 'ui-grid/groupingRowHeader',
+                  headerCellTemplate: 'ui-grid/groupingHeaderCell',
+                  enableColumnResizing: false,
+                  enableColumnMenu: false,
+                  exporterSuppressExport: true,
+                  allowCellFocus: true
+                };
+  
+                uiGridCtrl.grid.addRowHeaderColumn(groupingRowHeaderDef);
+                uiGridCtrl.grid.registerColumnBuilder( uiGridGroupingService.groupingColumnBuilder);
+              }
+            },
+            post: function ($scope, $elm, $attrs, uiGridCtrl) {
+
+            }
+          };
+        }
+      };
+    }]);
+
+
+  /**
+   *  @ngdoc directive
+   *  @name ui.grid.grouping.directive:uiGridGroupingRowHeaderButtons
+   *  @element div
+   *
+   *  @description Provides the expand/collapse button on groupHeader rows 
+   */
+  module.directive('uiGridGroupingRowHeaderButtons', ['$templateCache', 'uiGridGroupingService',
+    function ($templateCache, uiGridGroupingService) {
+      return {
+        replace: true,
+        restrict: 'E',
+        template: $templateCache.get('ui-grid/groupingRowHeaderButtons'),
+        scope: true,
+        require: '^uiGrid',
+        link: function($scope, $elm, $attrs, uiGridCtrl) {
+          var self = uiGridCtrl.grid;
+          $scope.groupButtonClick = function(row, evt) {
+            uiGridGroupingService.toggleRowGroupingState(self, row, evt);
+          };
+        }
+      };
+    }]);
+
+
+  /**
+   *  @ngdoc directive
+   *  @name ui.grid.grouping.directive:uiGridGroupingExpandAllButtons
+   *  @element div
+   *
+   *  @description Provides the expand/collapse all button 
+   */
+  module.directive('uiGridGroupingExpandAllButtons', ['$templateCache', 'uiGridGroupingService',
+    function ($templateCache, uiGridGroupingService) {
+      return {
+        replace: true,
+        restrict: 'E',
+        template: $templateCache.get('ui-grid/groupingExpandAllButtons'),
+        scope: false,
+        link: function($scope, $elm, $attrs, uiGridCtrl) {
+          var self = $scope.col.grid;
+
+          $scope.headerButtonClick = function(row, evt) {
+            if ( self.grouping.expandAll ){
+              uiGridGroupingService.collapseAllRows(self, evt);
+              self.grouping.expandAll = false;
+            } else {
+              uiGridGroupingService.expandAllRows(self, evt);
+              self.grouping.expandAll = true;
+            }
+          };
+        }
+      };
+    }]);
+
+  /**
+   *  @ngdoc directive
+   *  @name ui.grid.grouping.directive:uiGridViewport
+   *  @element div
+   *
+   *  @description Stacks on top of ui.grid.uiGridViewport to set formatting on a group header row
+   */
+  module.directive('uiGridViewport',
+    ['$compile', 'uiGridConstants', 'uiGridGroupingConstants', 'gridUtil', '$parse', 'uiGridGroupingService',
+      function ($compile, uiGridConstants, uiGridGroupingConstants, gridUtil, $parse, uiGridGroupingService) {
+        return {
+          priority: -200, // run after default  directive
+          scope: false,
+          compile: function ($elm, $attrs) {
+            var rowRepeatDiv = angular.element($elm.children().children()[0]);
+
+            var existingNgClass = rowRepeatDiv.attr("ng-class");
+            var newNgClass = '';
+            if ( existingNgClass ) {
+              newNgClass = existingNgClass.slice(0, -1) + ",'ui-grid-group-header-row': row.groupLevel > -1}";
+            } else {
+              newNgClass = "{'ui-grid-group-header-row': row.groupLevel > -1}";
+            }
+            rowRepeatDiv.attr("ng-class", newNgClass);
+
+            return {
+              pre: function ($scope, $elm, $attrs, controllers) {
+
+              },
+              post: function ($scope, $elm, $attrs, controllers) {
+              }
+            };
+          }
+        };
+      }]);
+
+})();

--- a/src/features/grouping/less/grouping.less
+++ b/src/features/grouping/less/grouping.less
@@ -1,0 +1,10 @@
+@import '../../../less/variables';
+
+.ui-grid-group-header-row {
+  font-weight: bold !important;
+}
+
+.ui-grid-grouping-row-header-buttons.ui-grid-group-header {
+  cursor: pointer;
+  opacity: 1;
+}

--- a/src/features/grouping/templates/groupingExpandAllButtons.html
+++ b/src/features/grouping/templates/groupingExpandAllButtons.html
@@ -1,0 +1,2 @@
+<div class="ui-grid-grouping-row-header-buttons" ng-class="{'ui-grid-icon-minus-squared': grid.grouping.expandAll, 'ui-grid-icon-plus-squared': !grid.grouping.expandAll}" ng-click="headerButtonClick($event)">
+</div>

--- a/src/features/grouping/templates/groupingHeaderCell.html
+++ b/src/features/grouping/templates/groupingHeaderCell.html
@@ -1,0 +1,6 @@
+<div>
+  <!-- <div class="ui-grid-vertical-bar">&nbsp;</div> -->
+  <div class="ui-grid-cell-contents" col-index="renderIndex">
+    <ui-grid-grouping-expand-all-buttons ></ui-grid-grouping-expand-all-buttons>
+  </div>
+</div>

--- a/src/features/grouping/templates/groupingRowHeader.html
+++ b/src/features/grouping/templates/groupingRowHeader.html
@@ -1,0 +1,3 @@
+<div class="ui-grid-cell-contents">
+  <ui-grid-grouping-row-header-buttons></ui-grid-grouping-row-header-buttons>
+</div>

--- a/src/features/grouping/templates/groupingRowHeaderButtons.html
+++ b/src/features/grouping/templates/groupingRowHeaderButtons.html
@@ -1,0 +1,4 @@
+<div class="ui-grid-grouping-row-header-buttons" ng-class="{'ui-grid-group-header': row.groupLevel > - 1}" ng-click="groupButtonClick(row, $event)">
+  <i ng-class="{'ui-grid-icon-minus-squared': row.expandedState.state === 'expanded', 'ui-grid-icon-plus-squared': row.expandedState.state === 'collapsed'}" ng-style="{'padding-left': grid.options.groupingIndent * row.groupLevel + 'px'}"></i>
+  &nbsp;
+</div>

--- a/src/features/grouping/test/grouping.spec.js
+++ b/src/features/grouping/test/grouping.spec.js
@@ -1,0 +1,687 @@
+describe('ui.grid.grouping uiGridGroupingService', function () {
+  var uiGridGroupingService;
+  var uiGridGroupingConstants;
+  var gridClassFactory;
+  var grid;
+  var $rootScope;
+  var $scope;
+  var GridRow;
+
+  beforeEach(module('ui.grid.grouping'));
+
+  beforeEach(inject(function (_uiGridGroupingService_,_gridClassFactory_, $templateCache, _uiGridGroupingConstants_,
+                              _$rootScope_, _GridRow_) {
+    uiGridGroupingService = _uiGridGroupingService_;
+    uiGridGroupingConstants = _uiGridGroupingConstants_;
+    gridClassFactory = _gridClassFactory_;
+    $rootScope = _$rootScope_;
+    $scope = $rootScope.$new();
+    GridRow = _GridRow_;
+
+    $templateCache.put('ui-grid/uiGridCell', '<div/>');
+    $templateCache.put('ui-grid/editableCell', '<div editable_cell_directive></div>');
+
+    grid = gridClassFactory.createGrid({});
+    grid.options.columnDefs = [
+      {field: 'col0', enableGrouping: true},
+      {field: 'col1', enableGrouping: true},
+      {field: 'col2', enableGrouping: true},
+      {field: 'col3', enableGrouping: true}
+    ];
+
+    _uiGridGroupingService_.initializeGrid(grid, $scope);
+    var data = [];
+    for (var i = 0; i < 10; i++) {
+      data.push({col0: 'a_' + Math.floor(i/4), col1: 'b_' + Math.floor(i/2), col2: 'c_' + i, col3: 'd_' + i});
+    }
+    grid.options.data = data;
+
+    grid.buildColumns();
+    grid.modifyRows(grid.options.data);
+  }));
+
+
+  describe( 'tidySortPriority', function() {
+    it( 'no group columns, no sort columns, no errors', function() {
+      uiGridGroupingService.tidyPriorities( grid );
+    });
+
+    it( 'some group columns, some sort columns, tidies correctly', function() {
+      grid.columns[0].sort = { priority: 1};
+      grid.columns[0].grouping = { groupPriority: 3};
+      grid.columns[1].sort = {priority: 9};
+      grid.columns[2].sort = {priority: 1};
+      grid.columns[2].grouping = { groupPriority: 2 };
+      grid.columns[3].sort = {priority: 0};
+      
+      uiGridGroupingService.tidyPriorities( grid );
+      expect(grid.columns[2].grouping.groupPriority).toEqual(0, 'column 2 groupPriority');
+      expect(grid.columns[2].sort.priority).toEqual(0, 'column 2 sort priority');
+      expect(grid.columns[0].grouping.groupPriority).toEqual(1, 'column 0 groupPriority');
+      expect(grid.columns[0].sort.priority).toEqual(1, 'column 0 sort priority');
+      expect(grid.columns[3].sort.priority).toEqual(2, 'column 3 sort priority');
+      expect(grid.columns[1].sort.priority).toEqual(3, 'column 1 sort priority');
+    });
+    
+  });
+
+
+  describe( 'moveGroupColumns', function() {
+    it( 'move some columns left, and some columns right', function() {
+      
+    });
+  });
+
+
+  describe( 'groupRows', function() {
+    it( 'group by col0 then col1', function() {
+      spyOn(gridClassFactory, 'rowTemplateAssigner').andCallFake( function() {});
+      grid.columns[0].grouping = { groupPriority: 1 };
+      grid.columns[1].grouping = { groupPriority: 2 };
+      
+      var groupedRows = uiGridGroupingService.groupRows.call( grid, grid.rows );
+
+/*      
+      console.log('data');
+      for (var i = 0; i < 10; i++) {
+        console.log(grid.options.data[i]);
+      }
+      
+      console.log('results');
+      for (i = 0; i < 18; i++) {
+        console.log(grid.rows[i].entity);
+      }
+*/      
+      expect( groupedRows.length ).toEqual( 18, 'we\'ve added 3 col0 headers, and 5 col2 headers' );
+    });
+  });
+
+  describe('initialiseProcessingState', function() {
+    it('no grouping', function() {
+      grid.columns[1].grouping = {aggregation: uiGridGroupingConstants.aggregation.COUNT};
+      grid.columns[3].grouping = {aggregation: uiGridGroupingConstants.aggregation.SUM};
+      
+      expect(uiGridGroupingService.initialiseProcessingState(grid)).toEqual([
+      ]);
+    });
+    
+    it('no aggregation', function() {
+      grid.columns[1].grouping = {groupPriority: 3};
+      grid.columns[3].grouping = {groupPriority: 2};
+
+      expect(uiGridGroupingService.initialiseProcessingState(grid)).toEqual([
+        { fieldName: 'col3', initialised: false, currentValue: null, currentGroupHeader: null, runningAggregations: {} },
+        { fieldName: 'col1', initialised: false, currentValue: null, currentGroupHeader: null, runningAggregations: {} }
+      ]);
+    });
+    
+    it('mixture of settings', function() {
+      grid.columns[0].grouping = {aggregation: uiGridGroupingConstants.aggregation.COUNT};
+      grid.columns[1].grouping = {groupPriority: 3};
+      grid.columns[2].grouping = {aggregation: uiGridGroupingConstants.aggregation.SUM};
+      grid.columns[3].grouping = {groupPriority: 2};
+
+      expect(uiGridGroupingService.initialiseProcessingState(grid)).toEqual([
+        { fieldName: 'col3', initialised: false, currentValue: null, currentGroupHeader: null, runningAggregations: {
+          col0: { type: uiGridGroupingConstants.aggregation.COUNT, value: null },
+          col2: { type: uiGridGroupingConstants.aggregation.SUM, value: null }
+        } },
+        { fieldName: 'col1', initialised: false, currentValue: null, currentGroupHeader: null, runningAggregations: {
+          col0: { type: uiGridGroupingConstants.aggregation.COUNT, value: null },
+          col2: { type: uiGridGroupingConstants.aggregation.SUM, value: null }
+        } }
+      ]);
+    });
+  });
+
+
+  describe('getGrouping', function() {
+    it('should find no grouping', function() {
+      expect(uiGridGroupingService.getGrouping(grid)).toEqual({
+        grouping: [],
+        aggregations: []
+      });
+    });
+    
+    it('finds one grouping', function() {
+      grid.columns[1].grouping = {groupPriority: 0};
+      expect(uiGridGroupingService.getGrouping(grid)).toEqual({ 
+        grouping: [{ field: 'col1', groupPriority: 0 }],
+        aggregations: []
+      });
+    });
+
+    it('finds one aggregation, has no priority', function() {
+      grid.columns[1].grouping = {aggregation: uiGridGroupingConstants.aggregation.COUNT};
+      expect(uiGridGroupingService.getGrouping(grid)).toEqual({
+        grouping: [],
+        aggregations: [{ field: 'col1', aggregation: uiGridGroupingConstants.aggregation.COUNT} ]
+      });
+    });
+
+    it('finds one aggregation, has a priority, aggregation is ignored', function() {
+      grid.columns[1].grouping = {groupPriority: 0, aggregation: uiGridGroupingConstants.aggregation.COUNT};
+      expect(uiGridGroupingService.getGrouping(grid)).toEqual({
+        grouping: [{ field: 'col1', groupPriority: 0 }],
+        aggregations: []
+      });
+    });
+
+    it('finds one aggregation, has no priority, aggregation is stored', function() {
+      grid.columns[1].grouping = {groupPriority: -1, aggregation: uiGridGroupingConstants.aggregation.COUNT};
+      expect(uiGridGroupingService.getGrouping(grid)).toEqual({
+        grouping: [],
+        aggregations: [ { field: 'col1', aggregation: uiGridGroupingConstants.aggregation.COUNT } ]
+      });
+    });
+
+    it('multiple finds, sorts correctly', function() {
+      grid.columns[1].grouping = {aggregation: uiGridGroupingConstants.aggregation.COUNT};
+      grid.columns[2].grouping = {groupPriority: 1};
+      grid.columns[3].grouping = {groupPriority: 0, aggregation: uiGridGroupingConstants.aggregation.COUNT};
+      expect(uiGridGroupingService.getGrouping(grid)).toEqual({
+        grouping: [
+          { field: 'col3', groupPriority: 0 },
+          { field: 'col2', groupPriority: 1 }
+        ],
+        aggregations: [
+          { field: 'col1', aggregation: uiGridGroupingConstants.aggregation.COUNT}
+        ]
+      });
+    });
+
+    it('different multiple finds, sorts correctly', function() {
+      grid.columns[1].grouping = {groupPriority: 0};
+      grid.columns[2].grouping = {groupPriority: 2};
+      grid.columns[3].grouping = {groupPriority: 1};
+      expect(uiGridGroupingService.getGrouping(grid)).toEqual({
+        grouping: [
+          { field: 'col1', groupPriority: 0 },
+          { field: 'col3', groupPriority: 1 },
+          { field: 'col2', groupPriority: 2 }
+       ],
+       aggregations: []
+      });
+    });
+
+    it('renumbers non-contiguous grouping', function() {
+      grid.columns[1].grouping = {groupPriority: 2};
+      grid.columns[2].grouping = {groupPriority: 6};
+      grid.columns[3].grouping = {groupPriority: 4};
+      expect(uiGridGroupingService.getGrouping(grid)).toEqual({
+        grouping: [
+          { field: 'col1', groupPriority: 0 },
+          { field: 'col3', groupPriority: 1 },
+          { field: 'col2', groupPriority: 2 }
+       ],
+       aggregations: []
+      });
+    });
+  });
+  
+
+  describe('insertGroupHeader', function() {
+    it('inserts a header in the middle', function() {
+      spyOn(gridClassFactory, 'rowTemplateAssigner').andCallFake( function() {});
+      var headerRow1 = new GridRow( {}, null, grid );
+      var headerRow2 = new GridRow( {}, null, grid );
+      var headerRow3 = new GridRow( {}, null, grid );
+
+      headerRow1.expandedState = { state: uiGridGroupingConstants.EXPANDED };
+      headerRow2.expandedState = { state: uiGridGroupingConstants.COLLAPSED };
+       
+      var processingStates = [
+        { 
+          fieldName: 'col1', 
+          initialised: true,
+          currentValue: 'test',
+          currentGroupHeader: headerRow1,
+          runningAggregations: {
+            agg1: { type: uiGridGroupingConstants.aggregation.MAX, value: '1234'},
+            agg2: { type: uiGridGroupingConstants.aggregation.MIN, value: 98 }
+          }
+        },
+        { 
+          fieldName: 'col2', 
+          initialised: true,
+          currentValue: 'blah',
+          currentGroupHeader: headerRow2,
+          runningAggregations: {
+            agg1: { type: uiGridGroupingConstants.aggregation.MAX, value: 'x'},
+            agg2: { type: uiGridGroupingConstants.aggregation.MIN, value: 22 }
+          }
+        },
+        { 
+          fieldName: 'col3', 
+          initialised: true,
+          currentValue: 'fred',
+          currentGroupHeader: headerRow3,
+          runningAggregations: {
+            agg1: { type: uiGridGroupingConstants.aggregation.MAX, value: 'y'},
+            agg2: { type: uiGridGroupingConstants.aggregation.MIN, value: 13 }
+          }
+        }
+      ];
+      
+      uiGridGroupingService.insertGroupHeader(grid, grid.rows, 3, processingStates, 1);
+      
+      expect( grid.rows.length ).toEqual(11, 'extra row created');
+      expect( grid.rows[3].entity).toEqual({col2: 'c_3'}, 'no aggregations yet, only the group title');
+      expect( grid.rows[3].entity).toEqual({col2: 'c_3'}, 'no aggregations yet, only the group title');
+      expect(headerRow2.entity).toEqual({ agg1: 'max: x', agg2: 'min: 22' });
+      expect(headerRow3.entity).toEqual({ agg1: 'max: y', agg2: 'min: 13' });
+      
+      expect( processingStates[0].currentGroupHeader ).toBe(headerRow1);
+      processingStates[0].currentGroupHeader = 'x';
+      expect( processingStates[1].currentGroupHeader ).toBe(grid.rows[3]);
+      processingStates[1].currentGroupHeader = 'y';
+      expect(processingStates).toEqual([
+        { 
+          fieldName: 'col1', 
+          initialised: true,
+          currentValue: 'test',
+          currentGroupHeader: 'x',
+          runningAggregations: {
+            agg1: { type: uiGridGroupingConstants.aggregation.MAX, value: '1234'},
+            agg2: { type: uiGridGroupingConstants.aggregation.MIN, value: 98 }
+          }
+        },
+        { 
+          fieldName: 'col2', 
+          initialised: true,
+          currentValue: 'c_3',
+          currentGroupHeader: 'y',
+          runningAggregations: {
+            agg1: { type: uiGridGroupingConstants.aggregation.MAX, value: null },
+            agg2: { type: uiGridGroupingConstants.aggregation.MIN, value: null }
+          }
+        },
+        { 
+          fieldName: 'col3', 
+          initialised: false,
+          currentValue: null,
+          currentGroupHeader: null,
+          runningAggregations: {
+            agg1: { type: uiGridGroupingConstants.aggregation.MAX, value: null },
+            agg2: { type: uiGridGroupingConstants.aggregation.MIN, value: null }
+          }
+        }
+      ]);
+    });
+  });
+
+
+  describe('writeOutAggregations', function() {
+    it('one state', function() {
+      var headerRow1 = new GridRow( {}, null, grid );
+       
+      var processingStates = [
+        { 
+          fieldName: 'col1', 
+          initialised: true,
+          currentValue: 'test',
+          currentGroupHeader: headerRow1,
+          runningAggregations: {
+            agg1: { type: uiGridGroupingConstants.aggregation.MAX, value: '1234'},
+            agg2: { type: uiGridGroupingConstants.aggregation.MIN, value: 98 }
+          }
+        }
+      ];
+      
+      uiGridGroupingService.writeOutAggregations( grid, processingStates, 0 );
+      
+      expect(headerRow1.entity).toEqual({ agg1: 'max: 1234', agg2: 'min: 98' });
+      expect(processingStates).toEqual([
+        {
+          fieldName: 'col1', 
+          initialised: false,
+          currentValue: null,
+          currentGroupHeader: null,
+          runningAggregations: {
+            agg1: { type: uiGridGroupingConstants.aggregation.MAX, value: null},
+            agg2: { type: uiGridGroupingConstants.aggregation.MIN, value: null }
+          }
+        }
+      ]);
+    });
+    
+    it('many states, start in the middle', function() {
+      var headerRow1 = new GridRow( {}, null, grid );
+      var headerRow2 = new GridRow( {}, null, grid );
+      var headerRow3 = new GridRow( {}, null, grid );
+       
+      var processingStates = [
+        { 
+          fieldName: 'col1', 
+          initialised: true,
+          currentValue: 'test',
+          currentGroupHeader: headerRow1,
+          runningAggregations: {
+            agg1: { type: uiGridGroupingConstants.aggregation.MAX, value: '1234'},
+            agg2: { type: uiGridGroupingConstants.aggregation.MIN, value: 98 }
+          }
+        },
+        { 
+          fieldName: 'col2', 
+          initialised: true,
+          currentValue: 'blah',
+          currentGroupHeader: headerRow2,
+          runningAggregations: {
+            agg1: { type: uiGridGroupingConstants.aggregation.MAX, value: 'x'},
+            agg2: { type: uiGridGroupingConstants.aggregation.MIN, value: 22 }
+          }
+        },
+        { 
+          fieldName: 'col3', 
+          initialised: true,
+          currentValue: 'fred',
+          currentGroupHeader: headerRow3,
+          runningAggregations: {
+            agg1: { type: uiGridGroupingConstants.aggregation.MAX, value: 'y'},
+            agg2: { type: uiGridGroupingConstants.aggregation.MIN, value: 13 }
+          }
+        }
+      ];
+      
+      uiGridGroupingService.writeOutAggregations( grid, processingStates, 1 );
+      
+      expect(headerRow1.entity).toEqual({});
+      expect(headerRow2.entity).toEqual({ agg1: 'max: x', agg2: 'min: 22' });
+      expect(headerRow3.entity).toEqual({ agg1: 'max: y', agg2: 'min: 13' });
+      
+      expect(processingStates).toEqual([
+        { 
+          fieldName: 'col1', 
+          initialised: true,
+          currentValue: 'test',
+          currentGroupHeader: headerRow1,
+          runningAggregations: {
+            agg1: { type: uiGridGroupingConstants.aggregation.MAX, value: '1234'},
+            agg2: { type: uiGridGroupingConstants.aggregation.MIN, value: 98 }
+          }
+        },
+        { 
+          fieldName: 'col2', 
+          initialised: false,
+          currentValue: null,
+          currentGroupHeader: null,
+          runningAggregations: {
+            agg1: { type: uiGridGroupingConstants.aggregation.MAX, value: null },
+            agg2: { type: uiGridGroupingConstants.aggregation.MIN, value: null }
+          }
+        },
+        { 
+          fieldName: 'col3', 
+          initialised: false,
+          currentValue: null,
+          currentGroupHeader: null,
+          runningAggregations: {
+            agg1: { type: uiGridGroupingConstants.aggregation.MAX, value: null },
+            agg2: { type: uiGridGroupingConstants.aggregation.MIN, value: null }
+          }
+        }
+      ]);
+    });    
+  });
+  
+
+  describe('writeOutAggregation', function() {
+    it('no rowHeader', function() {
+      var processingState = { 
+        fieldName: 'col1', 
+        initialised: true,
+        currentValue: 'test',
+        currentGroupHeader: null,
+        runningAggregations: {
+        }
+      };
+      
+      uiGridGroupingService.writeOutAggregation( grid, processingState );
+      
+      expect(processingState).toEqual({
+        fieldName: 'col1', 
+        initialised: false,
+        currentValue: null,
+        currentGroupHeader: null,
+        runningAggregations: {
+        }
+      });
+    });
+
+    it('no aggregations', function() {
+      var headerRow = new GridRow( {}, null, grid );
+       
+      var processingState = { 
+        fieldName: 'col1', 
+        initialised: true,
+        currentValue: 'test',
+        currentGroupHeader: headerRow,
+        runningAggregations: {
+        }
+      };
+      
+      uiGridGroupingService.writeOutAggregation( grid, processingState );
+      
+      expect(headerRow.entity).toEqual({});
+      expect(processingState).toEqual({
+        fieldName: 'col1', 
+        initialised: false,
+        currentValue: null,
+        currentGroupHeader: null,
+        runningAggregations: {
+        }
+      });
+    });
+
+    it('some aggregations', function() {
+      var headerRow = new GridRow( {}, null, grid );
+       
+      var processingState = { 
+        fieldName: 'col1', 
+        initialised: true,
+        currentValue: 'test',
+        currentGroupHeader: headerRow,
+        runningAggregations: {
+          agg1: { type: uiGridGroupingConstants.aggregation.MAX, value: '1234'},
+          agg2: { type: uiGridGroupingConstants.aggregation.MIN, value: 98 }
+        }
+      };
+      
+      uiGridGroupingService.writeOutAggregation( grid, processingState );
+      
+      expect(headerRow.entity).toEqual({ agg1: 'max: 1234', agg2: 'min: 98' });
+      expect(processingState).toEqual({
+        fieldName: 'col1', 
+        initialised: false,
+        currentValue: null,
+        currentGroupHeader: null,
+        runningAggregations: {
+          agg1: { type: uiGridGroupingConstants.aggregation.MAX, value: null},
+          agg2: { type: uiGridGroupingConstants.aggregation.MIN, value: null }
+        }
+      });
+    });
+  });
+  
+  
+  describe( 'getExpandedState', function() {
+    it( 'empty states', function() {
+      grid.grouping.rowExpandedStates = {};
+      
+      var processingStates = [
+        { 
+          fieldName: 'col1', 
+          currentValue: 'test'
+        },
+        { 
+          fieldName: 'col2', 
+          currentValue: 'blah'
+        },
+        { 
+          fieldName: 'col3', 
+          currentValue: 'fred'
+        }
+      ];
+      
+      var expandedState = uiGridGroupingService.getExpandedState( grid, processingStates, 1);
+      
+      expect( grid.grouping.rowExpandedStates ).toEqual(
+        {
+          test: {
+            state: 'collapsed',
+            blah: {
+              state: 'collapsed'
+            }
+          }
+        }
+      );
+      expect( expandedState ).toBe( grid.grouping.rowExpandedStates.test.blah);      
+    });
+
+    it( 'existing states', function() {
+      grid.grouping.rowExpandedStates = {
+        test: {
+          state: 'collapsed',
+          blah: {
+            state: 'collapsed'
+          },
+          fred: {
+            state: 'expanded'
+          }
+        }
+      };
+      
+      var processingStates = [
+        { 
+          fieldName: 'col1', 
+          currentValue: 'test'
+        },
+        { 
+          fieldName: 'col2', 
+          currentValue: 'blah'
+        },
+        { 
+          fieldName: 'col3', 
+          currentValue: 'fred'
+        }
+      ];
+      
+      var expandedState = uiGridGroupingService.getExpandedState( grid, processingStates, 1);
+      
+      expect( grid.grouping.rowExpandedStates ).toEqual(
+        {
+          test: {
+            state: 'collapsed',
+            blah: {
+              state: 'collapsed'
+            },
+            fred: {
+              state: 'expanded'
+            }
+          }
+        }
+      );
+      expect( expandedState ).toBe( grid.grouping.rowExpandedStates.test.blah);      
+    });
+  });
+  
+  
+  describe( 'setVisibility', function() {
+    it( 'invisible', function() {
+      var headerRow1 = new GridRow( {}, null, grid );
+      var headerRow2 = new GridRow( {}, null, grid );
+      
+      headerRow1.expandedState = { state: uiGridGroupingConstants.EXPANDED };
+      headerRow2.expandedState = { state: uiGridGroupingConstants.COLLAPSED };
+      
+      var processingStates = [
+        { 
+          fieldName: 'col1', 
+          currentGroupHeader: headerRow1
+        },
+        { 
+          fieldName: 'col2', 
+          currentGroupHeader: headerRow2
+        }
+      ];
+      
+      uiGridGroupingService.setVisibility( grid, grid.rows[1], processingStates );
+      expect( grid.rows[1].visible ).toEqual(false);
+      expect( grid.rows[1].invisibleReason.grouping).toEqual(true);
+    });
+
+    it( 'visible', function() {
+      var headerRow1 = new GridRow( {}, null, grid );
+      var headerRow2 = new GridRow( {}, null, grid );
+      
+      headerRow1.expandedState = { state: uiGridGroupingConstants.EXPANDED };
+      headerRow2.expandedState = { state: uiGridGroupingConstants.EXPANDED };
+      
+      var processingStates = [
+        { 
+          fieldName: 'col1', 
+          currentGroupHeader: headerRow1
+        },
+        { 
+          fieldName: 'col2', 
+          currentGroupHeader: headerRow2
+        }
+      ];
+      
+      uiGridGroupingService.setVisibility( grid, grid.rows[1], processingStates );
+      expect( grid.rows[1].visible ).toEqual(true);
+      expect( grid.rows[1].invisibleReason).toEqual(undefined);
+    });
+  });
+  
+  
+  describe( 'aggregate', function() {
+    it( 'aggregates many fields', function() {
+      var groupFieldState = {
+        runningAggregations: {
+          col0: { type: uiGridGroupingConstants.aggregation.COUNT, value: 3 },
+          col1: { type: uiGridGroupingConstants.aggregation.SUM, value: 48 },
+          col2: { type: uiGridGroupingConstants.aggregation.MAX, value: 5 },
+          col3: { type: uiGridGroupingConstants.aggregation.MIN, value: 28 }
+        }
+      };
+      
+      var row = new GridRow( { col0: 'x', col1: 10, col2: '7', col3: '22' }, null, grid );
+      
+      uiGridGroupingService.aggregate( grid, row, groupFieldState);
+      
+      expect( groupFieldState ).toEqual({
+        runningAggregations: {
+          col0: { type: uiGridGroupingConstants.aggregation.COUNT, value: 4 },
+          col1: { type: uiGridGroupingConstants.aggregation.SUM, value: 58 },
+          col2: { type: uiGridGroupingConstants.aggregation.MAX, value: '7' },
+          col3: { type: uiGridGroupingConstants.aggregation.MIN, value: '22' }
+        }
+      });
+    });
+
+    it( 'aggregates many fields, doesn\'t trigger max and min', function() {
+       var groupFieldState = {
+        runningAggregations: {
+          col0: { type: uiGridGroupingConstants.aggregation.COUNT, value: 3 },
+          col1: { type: uiGridGroupingConstants.aggregation.SUM, value: 48 },
+          col2: { type: uiGridGroupingConstants.aggregation.MAX, value: 5 },
+          col3: { type: uiGridGroupingConstants.aggregation.MIN, value: 28 }
+        }
+      };
+      
+      var row = new GridRow( { col0: 'x', col1: 10, col2: '3', col3: '30' }, null, grid );
+      
+      uiGridGroupingService.aggregate( grid, row, groupFieldState);
+      
+      expect( groupFieldState ).toEqual({
+        runningAggregations: {
+          col0: { type: uiGridGroupingConstants.aggregation.COUNT, value: 4 },
+          col1: { type: uiGridGroupingConstants.aggregation.SUM, value: 58 },
+          col2: { type: uiGridGroupingConstants.aggregation.MAX, value: 5 },
+          col3: { type: uiGridGroupingConstants.aggregation.MIN, value: 28 }
+        }
+      });
+    });
+  });
+});

--- a/src/font/config.json
+++ b/src/font/config.json
@@ -19,6 +19,12 @@
       "src": "fontawesome"
     },
     {
+      "uid": "12f4ece88e46abd864e40b35e05b11cd",
+      "css": "ok",
+      "code": 50018,
+      "src": "fontawesome"
+    },
+    {
       "uid": "5211af474d3a9848f67f945e2ccaf143",
       "css": "cancel",
       "code": 50003,
@@ -58,6 +64,12 @@
       "uid": "d35a1d35efeb784d1dc9ac18b9b6c2b6",
       "css": "pencil",
       "code": 50007,
+      "src": "fontawesome"
+    },
+    {
+      "uid": "559647a6f430b3aeadbecd67194451dd",
+      "css": "menu",
+      "code": 50019,
       "src": "fontawesome"
     },
     {
@@ -103,6 +115,18 @@
       "src": "fontawesome"
     },
     {
+      "uid": "594e9271c08ff732c04b3bf3117b9040",
+      "css": "indent-left",
+      "code": 59392,
+      "src": "fontawesome"
+    },
+    {
+      "uid": "4d2dfc45d8176b1f26aed973fa84a91e",
+      "css": "indent-right",
+      "code": 59393,
+      "src": "fontawesome"
+    },
+    {
       "uid": "4109c474ff99cad28fd5a2c38af2ec6f",
       "css": "filter",
       "code": 50015,
@@ -118,18 +142,6 @@
       "uid": "27b13eff5eb0ca15e01a6e65ffe6eeec",
       "css": "sort-alt-down",
       "code": 50017,
-      "src": "fontawesome"
-    },
-    {
-      "uid": "12f4ece88e46abd864e40b35e05b11cd",
-      "css": "ok",
-      "code": 50018,
-      "src": "fontawesome"
-    },
-    {
-      "uid": "559647a6f430b3aeadbecd67194451dd",
-      "css": "menu",
-      "code": 50019,
       "src": "fontawesome"
     }
   ]

--- a/src/js/core/directives/ui-grid-column-menu.js
+++ b/src/js/core/directives/ui-grid-column-menu.js
@@ -109,13 +109,6 @@ function ( i18nService, uiGridConstants, gridUtil ) {
     },
     
     /**
-     * @ngdoc boolean
-     * @name suppressRemoveSort
-     * @propertyOf ui.grid.class:GridOptions.columnDef
-     * @description (optional) False by default. When enabled, this setting hides the removeSort option
-     * in the menu.
-     */
-    /**
      * @ngdoc method
      * @methodOf ui.grid.service:uiGridColumnMenuService
      * @name suppressRemoveSort
@@ -124,7 +117,7 @@ function ( i18nService, uiGridConstants, gridUtil ) {
      * 
      */  
     suppressRemoveSort: function( $scope ) {
-      if ($scope.col && $scope.col.colDef && $scope.col.colDef.suppressRemoveSort) {
+      if ($scope.col && $scope.col.suppressRemoveSort) {
         return true;
       }
       else {

--- a/src/js/core/factories/GridColumn.js
+++ b/src/js/core/factories/GridColumn.js
@@ -457,6 +457,17 @@ angular.module('ui.grid')
     self.sortingAlgorithm = colDef.sortingAlgorithm;
 
     /**
+     * @ngdoc boolean
+     * @name suppressRemoveSort
+     * @propertyOf ui.grid.class:GridOptions.columnDef
+     * @description (optional) False by default. When enabled, this setting hides the removeSort option
+     * in the menu, and prevents users from manually removing the sort
+     */
+    if ( typeof(self.suppressRemoveSort) === 'undefined'){
+      self.suppressRemoveSort = typeof(colDef.suppressRemoveSort) !== 'undefined' ? colDef.suppressRemoveSort : false;
+    }
+    
+    /**
      * @ngdoc property
      * @name enableFiltering
      * @propertyOf ui.grid.class:GridOptions.columnDef

--- a/src/js/core/services/rowSearcher.js
+++ b/src/js/core/services/rowSearcher.js
@@ -328,8 +328,8 @@ module.service('rowSearcher', ['gridUtil', 'uiGridConstants', function (gridUtil
     if (filterData.length > 0) {
       // define functions outside the loop, performance optimisation
       var foreachRow = function(grid, row, col, filters){
-        if (row.forceInvisible || !rowSearcher.searchColumn(grid, row, col, filters)) {
-          row.visible = false;
+        if ( !rowSearcher.searchColumn(grid, row, col, filters) ) {
+          row.setThisRowInvisible('filtered', true);
         }
       };
       

--- a/src/js/i18n/en.js
+++ b/src/js/i18n/en.js
@@ -65,6 +65,15 @@
         pagination: {
           sizes: 'items per page',
           totalItems: 'items'
+        },
+        grouping: {
+          group: 'Group',
+          ungroup: 'Ungroup',
+          aggregate_count: 'Agg: Count',
+          aggregate_sum: 'Agg: Sum',
+          aggregate_max: 'Agg: Max',
+          aggregate_min: 'Agg: Min',
+          aggregate_remove: 'Agg: Remove'
         }
       });
       return $delegate;

--- a/test/unit/core/directives/ui-grid-column-menu.spec.js
+++ b/test/unit/core/directives/ui-grid-column-menu.spec.js
@@ -133,13 +133,13 @@ describe('ui-grid-column-menu uiGridColumnMenuService', function () {
   
   describe('suppressRemoveSort: ', function () {
     it('everything present: is suppressed', function () {
-      $scope.col = { uid: 'ui-grid-01x', colDef: { suppressRemoveSort: true } };
+      $scope.col = { uid: 'ui-grid-01x', suppressRemoveSort: true };
       
       expect( uiGridColumnMenuService.suppressRemoveSort( $scope ) ).toEqual( true );
     });  
 
     it('not set: is not suppressed', function () {
-      $scope.col = { uid: 'ui-grid-01x', colDef: {  } };
+      $scope.col = { uid: 'ui-grid-01x' };
       
       expect( uiGridColumnMenuService.suppressRemoveSort( $scope ) ).toEqual( false );
     });  

--- a/test/unit/core/factories/Grid.spec.js
+++ b/test/unit/core/factories/Grid.spec.js
@@ -696,16 +696,14 @@ describe('Grid factory', function () {
     });
 
     it( 'if sort is currently DESC, and suppressRemoveSort is null, then should toggle to null', function() {
-      column.sort = {direction: uiGridConstants.DESC};
-      column.colDef = { suppressRemoveSort: null };
+      column.sort = {direction: uiGridConstants.DESC, suppressRemoveSort: null};
       grid.sortColumn( column, false );
       
       expect( column.sort.direction ).toEqual(null);
     });
 
     it( 'if sort is currently DESC, and suppressRemoveSort is false, then should toggle to null', function() {
-      column.sort = {direction: uiGridConstants.DESC};
-      column.colDef = { suppressRemoveSort: false };
+      column.sort = {direction: uiGridConstants.DESC, suppressRemoveSort: false};
       grid.sortColumn( column, false );
       
       expect( column.sort.direction ).toEqual(null);
@@ -713,7 +711,7 @@ describe('Grid factory', function () {
 
     it( 'if sort is currently DESC, and suppressRemoveSort is true, then should toggle to ASC', function() {
       column.sort = {direction: uiGridConstants.DESC};
-      column.colDef = { suppressRemoveSort: true };
+      column.suppressRemoveSort = true;
       grid.sortColumn( column, false );
       
       expect( column.sort.direction ).toEqual(uiGridConstants.ASC);

--- a/test/unit/core/factories/GridRow.spec.js
+++ b/test/unit/core/factories/GridRow.spec.js
@@ -1,15 +1,16 @@
 describe('GridRow factory', function () {
-  var $q, $scope, grid, Grid, GridRow, gridUtil, gridClassFactory;
+  var $q, $scope, grid, Grid, GridRow, gridUtil, gridClassFactory, $timeout;
 
   beforeEach(module('ui.grid'));
 
-  beforeEach(inject(function (_$q_, _$rootScope_, _Grid_, _GridRow_, _gridUtil_, _gridClassFactory_) {
+  beforeEach(inject(function (_$q_, _$rootScope_, _Grid_, _GridRow_, _gridUtil_, _gridClassFactory_, _$timeout_) {
     $q = _$q_;
     $scope = _$rootScope_;
     Grid = _Grid_;
     GridRow = _GridRow_;
     gridUtil = _gridUtil_;
     gridClassFactory = _gridClassFactory_;
+    $timeout = _$timeout_;
   }));
 
 
@@ -66,32 +67,34 @@ describe('GridRow factory', function () {
       expect(grid.api.core.getVisibleRows(grid).length).toEqual(10, 'all rows visible');
       
       grid.api.core.setRowInvisible(grid.rows[0]);
-      expect(grid.rows[0].forceInvisible).toBe(true);
+      expect(grid.rows[0].invisibleReason.user).toBe(true);
       expect(grid.rows[0].visible).toBe(false);
       
       expect(rowsVisibleChanged).toEqual(true);
       $scope.$apply();
+      $timeout.flush();
       
       expect(grid.api.core.getVisibleRows(grid).length).toEqual(9, 'one row now invisible');
       
       rowsVisibleChanged = false;
 
       grid.api.core.clearRowInvisible(grid.rows[0]);
-      expect(grid.rows[0].forceInvisible).toBe(false);
+      expect(grid.rows[0].invisibleReason.user).toBe(undefined);
       expect(grid.rows[0].visible).toBe(true);
 
       expect(rowsVisibleChanged).toEqual(true);
       $scope.$apply();
+      $timeout.flush();
 
       expect(grid.api.core.getVisibleRows(grid).length).toEqual(10, 'should be visible again');
     });
 
-    it('should set then clear forceInvisible on invisible row, doesn\'t raise visible rows changed event', function () {
+    it('should set forceInvisible on invisible row, then clear forceInvisible visible row, doesn\'t raise visible rows changed event', function () {
       grid.api.core.on.rowsVisibleChanged( $scope, function() { rowsVisibleChanged = true; });
       grid.rows[0].visible = false;
       
       grid.api.core.setRowInvisible(grid.rows[0]);
-      expect(grid.rows[0].forceInvisible).toBe(true);
+      expect(grid.rows[0].invisibleReason.user).toBe(true);
       expect(grid.rows[0].visible).toBe(false);
       
       expect(rowsVisibleChanged).toEqual(false);
@@ -99,7 +102,7 @@ describe('GridRow factory', function () {
       grid.rows[0].visible = true;
       
       grid.api.core.clearRowInvisible(grid.rows[0]);
-      expect(grid.rows[0].forceInvisible).toBe(false);
+      expect(grid.rows[0].invisibleReason.user).toBe(undefined);
       expect(grid.rows[0].visible).toBe(true);
       
       expect(rowsVisibleChanged).toEqual(false);


### PR DESCRIPTION
This is a basic grouping function, providing a basis on which we
can extend and debug.  It provides:
- multilevel grouping
- aggregations on any non-grouped columns
- menu items to add/remove grouping
- menu items to add/remove aggregations
- API for manipulating grouping and rows
- groupingRowHeader to expand and collapse grouping.

The code builds on the sort logic, and heavily on the rowProcessor logic.
It adds internal rows to the rendered rows (but not grid.rows), these
are regenerated each time the rowProcessor runs.

It maintains expanded/collapsed state in grid.grouping.rowExpandedStates,
so that this persists across row builds.

It should interact cleanly with filtering and sorting.  It doesn't interact
well with edit and probably some of the other features.  It doesn't work well
with column bindings that are complex, and that needs some more thought - behind
the scenes it's creating a fake entity, and writing into that entity our aggregation
values.  If the fieldName isn't one we can easily deal with then writing to the entity
is hard.

This PR also includes a change to fontello config to restore fonts, and some changes
in core:

- changes to the way we handle invisible rows - include a new invisibleReason to replace
  the old forceInvisible, and changed logic to use it
- changes to suppressRemoveSort, which stops sorts from being messed up - it always used
  colDef, changed to copy down onto col.suppressRemoveSort and use from there, using this
  logic to stop the sort being messed up for grouped columns
- added a new queueGridRefresh() method to debounce grid refreshes.  Was using a lot of them.

More details are included in the tutorial, and some design information in the top of the code
file and therefore also in the root of the API:grouping documentation.