### PR TITLE
Adding functionality to help fix bug with row template and selection functionality.

### DIFF
--- a/src/features/selection/js/selection.js
+++ b/src/features/selection/js/selection.js
@@ -432,7 +432,11 @@
            *  @propertyOf  ui.grid.selection.api:GridOptions
            *  @description Makes it possible to specify a method that evaluates for each and sets its "enableSelection" property.
            */
-
+          if (gridOptions.rowTemplate !== false && !angular.isDefined(gridOptions.isRowSelectable)) {
+              gridOptions.isRowSelectable = function() {
+                return true;
+              };
+          }
           gridOptions.isRowSelectable = angular.isDefined(gridOptions.isRowSelectable) ? gridOptions.isRowSelectable : angular.noop;
         },
 
@@ -449,7 +453,11 @@
          */
         toggleRowSelection: function (grid, row, evt, multiSelect, noUnselect) {
           var selected = row.isSelected;
-
+          if (!angular.isDefined(selected) || selected === false) {
+              selected = false;
+          } else {
+              selected = true;
+          }
           if (!multiSelect && !selected) {
             service.clearSelectedRows(grid, evt);
           } else if (!multiSelect && selected) {
@@ -461,7 +469,7 @@
           }
 
           if (selected && noUnselect){
-            // don't deselect the row 
+            // don't deselect the row
           } else if (row.enableSelection !== false) {
             row.setSelected(!selected);
             if (row.isSelected === true) {


### PR DESCRIPTION
When adding a custom row template while using ui.grid.selection it causes the rowHeaderSelection checkmarks to stop functioning correctly.

This change will:
	- Set isRowSelectable to return true if a row template is passed in and there is no current function for isRowSelectable
	- explicity set the value of selected before it is passed into setSelected (in toggleRowSelection)