### PR TITLE
Make columns reorderable when debug false

### DIFF
--- a/src/directives/ng-header-cell.js
+++ b/src/directives/ng-header-cell.js
@@ -5,6 +5,9 @@
             return {
                 pre: function($scope, iElement) {
                     iElement.append($compile($scope.col.headerCellTemplate)($scope));
+                    // put $scope back on the element so element.scope() works even when
+                    // $compileProvider.debugInfoEnabled(false);
+                    iElement.data('$scope', $scope);
                 }
             };
         }


### PR DESCRIPTION
When $compileProvider.debugInfoEnabled(false) then element.scope() doesn't work. As a workaround, put $scope back on each header element.

https://docs.angularjs.org/api/ng/function/angular.element