### PR TITLE
Update rowSorter.js

### DIFF
--- a/src/js/core/services/rowSorter.js
+++ b/src/js/core/services/rowSorter.js
@@ -26,7 +26,7 @@ module.service('rowSorter', ['$parse', 'uiGridConstants', function ($parse, uiGr
     // Cache of sorting functions. Once we create them, we don't want to keep re-doing it
     //   this takes a piece of data from the cell and tries to determine its type and what sorting
     //   function to use for it
-    colSortFnCache: []
+    colSortFnCache: {}
   };
 
 


### PR DESCRIPTION
Updated rowSorter to use an object instead of an array. This fixes an edge case where, you have a column named "sort", and the code would basically overwrite the default Array.sort function. Here is a plunk demonstrating the bad behavior.

http://plnkr.co/edit/feSTTpNUEGoq4nnAz5KK?p=preview