### PR TITLE
Updates

### DIFF
--- a/misc/tutorial/209_grouping.ngdoc
+++ b/misc/tutorial/209_grouping.ngdoc
@@ -40,7 +40,6 @@ to allow people to start using it.  Notable outstandings are:
 - enhancement: allow a limit on number of columns grouped
 - consideration of RTL - not sure whether the indent/outdent should get reversed?
 - special formatting for header rows in exporter?
-- add grouping options to saveState
 
 Options to watch out for include:
 
@@ -54,6 +53,12 @@ Options to watch out for include:
   an average 
 - `groupingShowCounts`: set to false if you don't like the counts against the groupHeaders 
    
+ If you would like to suppress the data in a grouped column (so it only shows in the groupHeader rows) this can
+ be done by overriding the cellTemplate for any of the columns you allow grouping on as follows:
+   `cellTemplate: '<div ng-if="(!col.grouping || typeof(col.grouping.groupPriority) === \'undefined\') || ( row.groupHeader && col.grouping.groupPriority === row.groupLevel )" class="ui-grid-cell-contents" title="TOOLTIP">{{COL_FIELD CUSTOM_FILTERS}}</div>'`
+   
+ In the example below this has been done on the state column only.  This isn't included in the base code as it
+ could potentially interact with people's custom templates.
 
 @example
 In this example we group by the state column then the gender column, and we count the names (a proxy for 
@@ -73,7 +78,7 @@ we can't easily see that it's an average.
           { name: 'gender', grouping: { groupPriority: 1 }, sort: { direction: 'asc' }, width: '20%' },
           { name: 'age', grouping: { aggregation: uiGridGroupingConstants.aggregation.MAX }, width: '20%' },
           { name: 'company', width: '25%' },
-          { name: 'state', grouping: { groupPriority: 0 }, sort: { direction: 'desc' }, width: '35%' },
+          { name: 'state', grouping: { groupPriority: 0 }, sort: { direction: 'desc' }, width: '35%', cellTemplate: '<div ng-if="(!col.grouping || typeof(col.grouping.groupPriority) === \'undefined\') || ( row.groupHeader && col.grouping.groupPriority === row.groupLevel )" class="ui-grid-cell-contents" title="TOOLTIP">{{COL_FIELD CUSTOM_FILTERS}}</div>' },
           { name: 'balance', width: '25%', cellFilter: 'currency', groupingSuppressAggregationText: true, grouping: { aggregation: uiGridGroupingConstants.aggregation.AVG } }
         ],
         onRegisterApi: function( gridApi ) {

--- a/misc/tutorial/209_grouping.ngdoc
+++ b/misc/tutorial/209_grouping.ngdoc
@@ -29,13 +29,24 @@ The group rowHeader by default is only visible when one or more columns are grou
 to have no visual impact when grouping is turned on but unused.  If you'd like the groupRowHeader permanently
 present then set the `groupingRowHeaderAlwaysVisible: true` gridOption.
 
+If you want to change the grouping programmatically after grid initialisation, you do this through calling the
+provided methods:
+
+  - `groupColumn`: groups an individual column.  Adds it to the end of the current grouping - so you need to remove
+    existing grouped columns first if you wanted this to be the only grouping.  Adds a sort ASC if there isn't one
+  - `ungroupColumn`: ungroups an individual column
+  - `aggregateColumn`: sets aggregation on a column, including setting the aggregation off.  Automatically removes
+    any sort first.
+  - `setGrouping`: sets all the grouping in one go, removing existing grouping
+  - `getGrouping`: gets the grouping config for the grid
+  - `clearGrouping`: clears all current grouping settings
+
 Grouping is still alpha, and under development, however it is included in the distribution files
 to allow people to start using it.  Notable outstandings are:
 
 - does not correctly handle columns that are based on functions or complex objects.  The groupHeader rows create
   a fake row.entity, and then set the appropriate fields in that entity.  This doesn't work well with 
   complex column definitions at present
-- notify data change capability is needed for when people programmatically change the grouping  
 - some more unit testing
 - enhancement: allow a limit on number of columns grouped
 - consideration of RTL - not sure whether the indent/outdent should get reversed?
@@ -52,13 +63,16 @@ Options to watch out for include:
   visual indication of what sort of aggregation is going on.  Refer the example below, the balance column with
   an average 
 - `groupingShowCounts`: set to false if you don't like the counts against the groupHeaders 
+  
+ 
+If you would like to suppress the data in a grouped column (so it only shows in the groupHeader rows) this can
+be done by overriding the cellTemplate for any of the columns you allow grouping on as follows:
+
+   `cellTemplate: '<div ng-if="!col.grouping || col.grouping.groupPriority === undefined || col.grouping.groupPriority === null || ( row.groupHeader && col.grouping.groupPriority === row.groupLevel )" class="ui-grid-cell-contents" title="TOOLTIP">{{COL_FIELD CUSTOM_FILTERS}}</div>'`
    
- If you would like to suppress the data in a grouped column (so it only shows in the groupHeader rows) this can
- be done by overriding the cellTemplate for any of the columns you allow grouping on as follows:
-   `cellTemplate: '<div ng-if="(!col.grouping || typeof(col.grouping.groupPriority) === \'undefined\') || ( row.groupHeader && col.grouping.groupPriority === row.groupLevel )" class="ui-grid-cell-contents" title="TOOLTIP">{{COL_FIELD CUSTOM_FILTERS}}</div>'`
-   
- In the example below this has been done on the state column only.  This isn't included in the base code as it
- could potentially interact with people's custom templates.
+In the example below this has been done on the state column only.  This isn't included in the base code as it
+could potentially interact with people's custom templates.
+
 
 @example
 In this example we group by the state column then the gender column, and we count the names (a proxy for 
@@ -75,10 +89,10 @@ we can't easily see that it's an average.
         enableFiltering: true,
         columnDefs: [
           { name: 'name', width: '30%' },
-          { name: 'gender', grouping: { groupPriority: 1 }, sort: { direction: 'asc' }, width: '20%' },
+          { name: 'gender', grouping: { groupPriority: 1 }, sort: { priority: 1, direction: 'asc' }, width: '20%' },
           { name: 'age', grouping: { aggregation: uiGridGroupingConstants.aggregation.MAX }, width: '20%' },
           { name: 'company', width: '25%' },
-          { name: 'state', grouping: { groupPriority: 0 }, sort: { direction: 'desc' }, width: '35%', cellTemplate: '<div ng-if="(!col.grouping || typeof(col.grouping.groupPriority) === \'undefined\') || ( row.groupHeader && col.grouping.groupPriority === row.groupLevel )" class="ui-grid-cell-contents" title="TOOLTIP">{{COL_FIELD CUSTOM_FILTERS}}</div>' },
+          { name: 'state', grouping: { groupPriority: 0 }, sort: { priority: 0, direction: 'desc' }, width: '35%', cellTemplate: '<div><div ng-if="!col.grouping || col.grouping.groupPriority === undefined || col.grouping.groupPriority === null || ( row.groupHeader && col.grouping.groupPriority === row.groupLevel )" class="ui-grid-cell-contents" title="TOOLTIP">{{COL_FIELD CUSTOM_FILTERS}}</div></div>' },
           { name: 'balance', width: '25%', cellFilter: 'currency', groupingSuppressAggregationText: true, grouping: { aggregation: uiGridGroupingConstants.aggregation.AVG } }
         ],
         onRegisterApi: function( gridApi ) {
@@ -92,6 +106,7 @@ we can't easily see that it's an average.
          data[i].state = data[i].address.state;
          data[i].balance = Number( data[i].balance.slice(1).replace(/,/,'') );
        }
+       delete data[2].age;
        $scope.gridOptions.data = data;
      });
  
@@ -101,16 +116,23 @@ we can't easily see that it's an average.
       
       $scope.toggleRow = function( rowNum ){
         $scope.gridApi.grouping.toggleRowGroupingState($scope.gridApi.grid.renderContainers.body.visibleRowCache[rowNum]);
-      }
+      };
+      
+      $scope.changeGrouping = function() {
+        $scope.gridApi.grouping.clearGrouping();
+        $scope.gridApi.grouping.groupColumn('age');
+        $scope.gridApi.grouping.aggregateColumn('state', uiGridGroupingConstants.aggregation.COUNT);
+      };
     }]);
   </file>
   
   <file name="index.html">
     <div ng-controller="MainCtrl">
-      <div id="grid1" ui-grid="gridOptions" ui-grid-grouping ui-grid-pinning class="grid"></div>
       <button id="expandAll" type="button" class="btn btn-success" ng-click="expandAll()">Expand All</button>
       <button id="toggleFirstRow" type="button" class="btn btn-success" ng-click="toggleRow(0)">Toggle First Row</button>
       <button id="toggleSecondRow" type="button" class="btn btn-success" ng-click="toggleRow(1)">Toggle Second Row</button>
+      <button id="changeGrouping" type="button" class="btn btn-success" ng-click="changeGrouping()">Change Grouping</button>
+      <div id="grid1" ui-grid="gridOptions" ui-grid-grouping ui-grid-pinning class="grid"></div>
     </div>
   </file>
   

--- a/misc/tutorial/210_selection.ngdoc
+++ b/misc/tutorial/210_selection.ngdoc
@@ -36,6 +36,11 @@ The selectAll box can be disabled by setting `enableSelectAll` to false.
 
 You can set the selection row header column width by setting 'selectionRowHeaderWidth' option.
 
+You can use an `isRowSelectable` function to determine which rows are selectable.  If you set this function in the options
+after grid initialisation you need to call `gridApi.core.notifyDataChange(uiGridConstants.dataChange.OPTIONS)` to enable
+the option.  In the grid below pressing the button to "set selectable" will set any rows that have an age > 30 to not be
+selectable, and also set the age of the first row to 31.
+
 @example
 Two examples are provided, the first with rowHeaderSelection and multi-select, the second without.  The first example
 auto-selects the first row once the data is loaded.
@@ -44,7 +49,7 @@ auto-selects the first row once the data is loaded.
   <file name="app.js">
     var app = angular.module('app', ['ngTouch', 'ui.grid', 'ui.grid.selection']);
 
-    app.controller('MainCtrl', ['$scope', '$http', '$log', '$timeout', function ($scope, $http, $log, $timeout) {
+    app.controller('MainCtrl', ['$scope', '$http', '$log', '$timeout', 'uiGridConstants', function ($scope, $http, $log, $timeout, uiGridConstants) {
       $scope.gridOptions = { 
         enableRowSelection: true,
         enableSelectAll: true,
@@ -92,6 +97,22 @@ auto-selects the first row once the data is loaded.
 
         $scope.toggleRow1 = function() {
           $scope.gridApi.selection.toggleRowSelection($scope.gridOptions.data[0]);
+        };
+        
+        $scope.setSelectable = function() {
+          $scope.gridApi.selection.clearSelectedRows();
+
+          $scope.gridOptions.isRowSelectable = function(row){
+            if(row.entity.age > 30){
+              return false;
+            } else {
+              return true;
+            }
+          };
+          $scope.gridApi.core.notifyDataChange(uiGridConstants.dataChange.OPTIONS);
+          
+          $scope.gridOptions.data[0].age = 31;
+          $scope.gridApi.core.notifyDataChange(uiGridConstants.dataChange.EDIT);
         };
 
         $scope.gridOptions.onRegisterApi = function(gridApi){
@@ -152,6 +173,7 @@ auto-selects the first row once the data is loaded.
       <br/>
       <button type="button" class="btn btn-success" ng-disabled="!gridApi.grid.options.multiSelect" ng-click="selectAll()">Select All</button>
       <button type="button" class="btn btn-success" ng-click="clearAll()">Clear All</button>
+      <button type="button" class="btn btn-success" ng-click="setSelectable()">Set Selectable</button>
       <br/>
 
       <div ui-grid="gridOptions" ui-grid-selection class="grid"></div>

--- a/src/features/grouping/test/grouping.spec.js
+++ b/src/features/grouping/test/grouping.spec.js
@@ -81,17 +81,6 @@ describe('ui.grid.grouping uiGridGroupingService', function () {
       
       var groupedRows = uiGridGroupingService.groupRows.call( grid, grid.rows );
 
-/*      
-      console.log('data');
-      for (var i = 0; i < 10; i++) {
-        console.log(grid.options.data[i]);
-      }
-      
-      console.log('results');
-      for (i = 0; i < 18; i++) {
-        console.log(grid.rows[i].entity);
-      }
-*/      
       expect( groupedRows.length ).toEqual( 18, 'we\'ve added 3 col0 headers, and 5 col2 headers' );
     });
   });

--- a/src/features/grouping/test/grouping.spec.js
+++ b/src/features/grouping/test/grouping.spec.js
@@ -363,6 +363,41 @@ describe('ui.grid.grouping uiGridGroupingService', function () {
     });
 
   });
+
+
+  describe('clearGrouping', function() {
+    it('no grouping', function() {
+      grid.api.grouping.setGrouping(
+        {}
+      );
+      
+      // really just checking there are no errors, it should do nothing
+      grid.api.grouping.clearGrouping();
+      
+      expect(grid.api.grouping.getGrouping( true )).toEqual(
+        { grouping: [], aggregations: [], rowExpandedStates: {} }
+      );
+    });
+
+    it('clear grouping, aggregations and rowExpandedStates', function() {
+      grid.api.grouping.setGrouping({
+        grouping: [
+          { field: 'col3', colName: 'col3', groupPriority: 0 },
+          { field: 'col2', colName: 'col2', groupPriority: 1 }
+        ],
+        aggregations: [
+          { field: 'col1', colName: 'col1', aggregation: uiGridGroupingConstants.aggregation.COUNT}
+        ],
+        rowExpandedStates: { male: { state: 'expanded' } } 
+      });
+      grid.api.grouping.clearGrouping();
+      
+      expect(grid.api.grouping.getGrouping( true )).toEqual(
+        { grouping: [], aggregations: [], rowExpandedStates: { male : { state : 'expanded' } } }
+      );
+    });
+
+  });
     
 
   describe('insertGroupHeader', function() {

--- a/src/features/row-edit/js/gridRowEdit.js
+++ b/src/features/row-edit/js/gridRowEdit.js
@@ -226,7 +226,6 @@
             var promise = grid.api.rowEdit.raise.saveRow( gridRow.entity );
             
             if ( gridRow.rowEditSavePromise ){
-              console.log(gridRow.rowEditSavePromise);
               gridRow.rowEditSavePromise.then( self.processSuccessPromise( grid, gridRow ), self.processErrorPromise( grid, gridRow ));
             } else {
               gridUtil.logError( 'A promise was not returned when saveRow event was raised, either nobody is listening to event, or event handler did not return a promise' );

--- a/src/js/core/factories/GridColumn.js
+++ b/src/js/core/factories/GridColumn.js
@@ -600,16 +600,16 @@ angular.module('ui.grid')
       self.setPropertyOrDefault(colDef, 'filters', defaultFilters);
     } else if ( self.filters.length === defaultFilters.length ) {
       self.filters.forEach( function( filter, index ){
-        if (typeof(filter.placeholder) !== 'undefined') {
+        if (typeof(defaultFilters[index].placeholder) !== 'undefined') {
           filter.placeholder = defaultFilters[index].placeholder;
         }
-        if (typeof(filter.flags) !== 'undefined') {
+        if (typeof(defaultFilters[index].flags) !== 'undefined') {
           filter.flags = defaultFilters[index].flags;
         }
-        if (typeof(filter.type) !== 'undefined') {
+        if (typeof(defaultFilters[index].type) !== 'undefined') {
           filter.type = defaultFilters[index].type;
         }
-        if (typeof(filter.selectOptions) !== 'undefined') {
+        if (typeof(defaultFilters[index].selectOptions) !== 'undefined') {
           filter.selectOptions = defaultFilters[index].selectOptions;
         }
       });

--- a/src/js/core/factories/GridColumn.js
+++ b/src/js/core/factories/GridColumn.js
@@ -528,7 +528,9 @@ angular.module('ui.grid')
     if (colDef.filter) {
       defaultFilters.push(colDef.filter);
     }
-    else {
+    else if ( colDef.filters ){
+      defaultFilters = colDef.filters;
+    } else {
       // Add an empty filter definition object, which will
       // translate to a guessed condition and no pre-populated
       // value for the filter <input>.
@@ -592,9 +594,25 @@ angular.module('ui.grid')
     // Only set filter if this is a newly added column, if we're updating an existing
     // column then we don't want to put the default filter back if the user may have already
     // removed it.
+    // However, we do want to keep the settings if they change, just not the term
     if ( isNew ) {
       self.setPropertyOrDefault(colDef, 'filter');
       self.setPropertyOrDefault(colDef, 'filters', defaultFilters);
+    } else if ( self.filters.length === defaultFilters.length ) {
+      self.filters.forEach( function( filter, index ){
+        if (typeof(filter.placeholder) !== 'undefined') {
+          filter.placeholder = defaultFilters[index].placeholder;
+        }
+        if (typeof(filter.flags) !== 'undefined') {
+          filter.flags = defaultFilters[index].flags;
+        }
+        if (typeof(filter.type) !== 'undefined') {
+          filter.type = defaultFilters[index].type;
+        }
+        if (typeof(filter.selectOptions) !== 'undefined') {
+          filter.selectOptions = defaultFilters[index].selectOptions;
+        }
+      });
     }
 
     // Remove this column from the grid sorting, include inside build columns so has

--- a/src/js/core/services/gridClassFactory.js
+++ b/src/js/core/services/gridClassFactory.js
@@ -49,7 +49,7 @@
           // Reset all rows to visible initially
           grid.registerRowsProcessor(function allRowsVisible(rows) {
             rows.forEach(function (row) {
-              row.visible = !row.forceInvisible;
+              row.visible = true;
             });
 
             return rows;

--- a/src/js/core/services/rowSorter.js
+++ b/src/js/core/services/rowSorter.js
@@ -413,7 +413,7 @@ module.service('rowSorter', ['$parse', 'uiGridConstants', function ($parse, uiGr
     
     // put a custom index field on each row, used to make a stable sort out of unstable sorts (e.g. Chrome)
     var setIndex = function( row, idx ){
-      row.entity.$uiGridIndex = idx;
+      row.entity.$$uiGridIndex = idx;
     };
     rows.forEach(setIndex);
 
@@ -443,7 +443,7 @@ module.service('rowSorter', ['$parse', 'uiGridConstants', function ($parse, uiGr
       // then return the previous order using our custom
       // index variable
       if (tem === 0 ) {
-        return rowA.entity.$uiGridIndex - rowB.entity.$uiGridIndex;
+        return rowA.entity.$$uiGridIndex - rowB.entity.$$uiGridIndex;
       }
       
       // Made it this far, we don't have to worry about null & undefined
@@ -458,9 +458,9 @@ module.service('rowSorter', ['$parse', 'uiGridConstants', function ($parse, uiGr
     
     // remove the custom index field on each row, used to make a stable sort out of unstable sorts (e.g. Chrome)
     var clearIndex = function( row, idx ){
-       delete row.entity.$uiGridIndex;
+       delete row.entity.$$uiGridIndex;
     };
-    rows.forEach(setIndex);
+    rows.forEach(clearIndex);
     
     return newRows;
   };

--- a/test/unit/core/factories/GridColumn.spec.js
+++ b/test/unit/core/factories/GridColumn.spec.js
@@ -67,6 +67,30 @@ describe('GridColumn factory', function () {
       });
     });
 
+    it('should update everything but term when updating filters', function () {
+      var filter = { term: 'x', placeholder: 'placeholder', type: uiGridConstants.filter.SELECT, selectOptions: [ { value: 1, label: "male" } ] };
+      grid.options.columnDefs[0].filter = filter;
+
+      runs(buildCols);
+
+      runs(function () {
+        expect(grid.columns[0].filters).toEqual([ { placeholder: 'placeholder', type: uiGridConstants.filter.SELECT, selectOptions: [ { value: 1, label: "male" } ] } ] );
+      });
+    });
+
+
+    it('should update everything but term when updating filters', function () {
+      var filters = [{ term: 'x', placeholder: 'placeholder', type: uiGridConstants.filter.SELECT, selectOptions: [ { value: 1, label: "male" } ] }];
+      grid.options.columnDefs[0].filters = filters;
+
+      runs(buildCols);
+
+      runs(function () {
+        expect(grid.columns[0].filters).toEqual([ { placeholder: 'placeholder', type: uiGridConstants.filter.SELECT, selectOptions: [ { value: 1, label: "male" } ] } ] );
+      });
+    });
+
+
 
     it('should obey columnDef sort spec', function () {
       // ... TODO(c0bra)


### PR DESCRIPTION
Fix a variety of things:

- enh(filters): allow changes to colDef.filter, other than term which would overwrite user input
- fix #3074, $$uiGridIndex
- fix grouping and rowEdit - remove console.logs that had crept in
- fix(filtering) allow programmatic changing to filtering
- fix(gridFactory): forceInvisible was still being used, it's not a valid option any more
- enh(selection): #3054 allow dynamic change to isRowSelectable, and evaluate it again after data change
- grouping doco: update tut for #3052 - cellTemplate that suppresses data in grouped rows
- enh(grouping): fix #2996 allow programmatic get and set of grouping