### PR TITLE
Date Filter support other formats

### DIFF
--- a/src/js/core/services/rowSearcher.js
+++ b/src/js/core/services/rowSearcher.js
@@ -226,7 +226,11 @@ module.service('rowSearcher', ['gridUtil', 'uiGridConstants', function (gridUtil
     if (filter.flags.date === true) {
       value = new Date(value);
       // If the term has a dash in it, it comes through as '\-' -- we need to take out the '\'.
-      term = new Date(term.replace(/\\/g, ''));
+      if (column.cellFilter) {
+        term = moment(term.replace(/\\/g, ''), column.cellFilter.split(':')[1].toUpperCase()).toDate();
+      } else {
+        term = new Date(term.replace(/\\/g, ''));
+      }
     }
 
     if (filter.condition === uiGridConstants.filter.GREATER_THAN) {


### PR DESCRIPTION
Date Filter only support yyyy-m-d format.

![image](https://cloud.githubusercontent.com/assets/7308292/6725944/432bcae6-cdef-11e4-98c7-906fbde94bae.png)

This PR uses CellFilter to Date Filter format. So we can use other formats like dd/mm/yyyy, mm/dd/yyy, etc..

It is necessary to include moment.js as a dependecy.