### PR TITLE
fix(uiGrid): Wait for grid to get dimensions before rendering

### DIFF
--- a/misc/demo/modal.html
+++ b/misc/demo/modal.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html ng-app="app">
+
+  <head>
+    <link data-require="bootstrap@*" data-semver="3.3.2" rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap.min.css" />
+    <script data-require="jquery@2.1.3" data-semver="2.1.3" src="http://code.jquery.com/jquery-2.1.3.min.js"></script>
+    <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.2.26/angular.js"></script>
+    <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.2.26/angular-touch.js"></script>
+    <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.2.26/angular-animate.js"></script>
+    <script data-require="ui-bootstrap@*" data-semver="0.12.1" src="http://angular-ui.github.io/bootstrap/ui-bootstrap-tpls-0.12.1.min.js"></script>
+    <script src="http://ui-grid.info/docs/grunt-scripts/csv.js"></script>
+    <script src="http://ui-grid.info/docs/grunt-scripts/pdfmake.js"></script>
+    <script src="http://ui-grid.info/docs/grunt-scripts/vfs_fonts.js"></script>
+    <script src="/dist/release/ui-grid.js"></script>
+    <link rel="stylesheet" href="/dist/release/ui-grid.css" type="text/css" />
+    <style type="text/css">
+        .grid {
+          width: 100%;
+          max-width: 600px;
+          height: 400px;
+        }
+
+        body {
+          padding: 20px;
+        }
+    </style>
+  </head>
+
+  <body>
+    <div ng-controller="MainCtrl">
+      <button ng-click="openModal()" class="btn btn-success">Open Modal</button>
+    </div>
+
+    <script>
+        var app = angular.module('app', ['ui.grid', 'ui.bootstrap']);
+
+        app.controller('MainCtrl', function ($scope, $modal) {
+          $scope.openModal = function () {
+            $modal.open({
+              templateUrl: 'modal.html'
+            });
+          }
+        });
+
+        app.controller('ModalDemoCtrl', function ($scope, $http) {
+          $scope.gridOptions = {};
+
+          $http.get('https://cdn.rawgit.com/angular-ui/ui-grid.info/gh-pages/data/500_complex.json')
+            .success(function(data) {
+              $scope.gridOptions.data = data;
+            });
+        });
+    </script>
+
+    <script type="text/ng-template" id="modal.html">
+        <div ng-controller="ModalDemoCtrl">
+                <div class="modal-header">
+                    <h3 class="modal-title">I'm a modal!</h3>
+                </div>
+                <div class="modal-body">
+                    <div id="grid1" ui-grid="gridOptions" class="grid"></div>
+                </div>
+                <div class="modal-footer">
+                    <button class="btn btn-warning" ng-click="$close()">Cancel</button>
+                </div>
+            <div ng-show="selected">Selection from a modal: {{ selected }}</div>
+        </div>
+    </script>
+</body>
+</html>

--- a/src/js/core/directives/ui-pinned-container.js
+++ b/src/js/core/directives/ui-pinned-container.js
@@ -33,7 +33,7 @@
                 }
 
                 return width;
-              }              
+              }
             }
             
             function updateContainerDimensions() {

--- a/src/js/core/services/ui-grid-util.js
+++ b/src/js/core/services/ui-grid-util.js
@@ -106,7 +106,7 @@ function augmentWidthOrHeight( elem, name, extra, isBorderBox, styles ) {
 function getWidthOrHeight( elem, name, extra ) {
   // Start with offset property, which is equivalent to the border-box value
   var valueIsBorderBox = true,
-          val,
+          val, // = name === 'width' ? elem.offsetWidth : elem.offsetHeight,
           styles = getStyles(elem),
           isBorderBox = styles['boxSizing'] === 'border-box';
 
@@ -172,6 +172,8 @@ var uidPrefix = 'uiGrid-';
 module.service('gridUtil', ['$log', '$window', '$document', '$http', '$templateCache', '$timeout', '$injector', '$q', '$interpolate', 'uiGridConstants',
   function ($log, $window, $document, $http, $templateCache, $timeout, $injector, $q, $interpolate, uiGridConstants) {
   var s = {
+
+    augmentWidthOrHeight: augmentWidthOrHeight,
 
     getStyles: getStyles,
 
@@ -786,8 +788,8 @@ module.service('gridUtil', ['$log', '$window', '$document', '$http', '$templateC
       if (e) {
         var styles = getStyles(e);
         return e.offsetWidth === 0 && rdisplayswap.test(styles.display) ?
-                  s.fakeElement(e, cssShow, function(newElm) {
-                    return getWidthOrHeight( newElm, name, extra );
+                  s.swap(e, cssShow, function() {
+                    return getWidthOrHeight(e, name, extra );
                   }) :
                   getWidthOrHeight( e, name, extra );
       }

--- a/src/less/header.less
+++ b/src/less/header.less
@@ -7,7 +7,7 @@
 
 .ui-grid-header {
   border-bottom: 1px solid @borderColor;
-  box-sizing: content-box;
+  box-sizing: border-box;
 }
 
 .ui-grid-top-panel {

--- a/src/less/menu.less
+++ b/src/less/menu.less
@@ -28,7 +28,7 @@
   overflow: hidden;
   padding: 0 10px 20px 10px;
   cursor: pointer;
-  box-sizing: content-box;
+  box-sizing: border-box;
 }
 
 .ui-grid-menu .ui-grid-menu-inner {

--- a/test/unit/core/services/ui-grid-util.spec.js
+++ b/test/unit/core/services/ui-grid-util.spec.js
@@ -199,7 +199,8 @@ describe('ui.grid.utilService', function() {
         expect(w).toEqual(300);
       });
 
-      it('should work with hidden element', function() {
+      // Width is no longer calculated for hidden elements
+      xit('should work with hidden element', function() {
         angular.element(elm).remove();
 
         elm = document.createElement('div');


### PR DESCRIPTION
This is a fix for #2700 and a few other issues.

The problem here is that for determining the grid width, gridUtil is detecting that when the grid is initialized, it has an offsetWidth of 0, so it creates a "fake" (cloned) element that it attaches to the document with visibility: hidden in order to measure it.

This causes a problem because with width: 100% when attached to the document body the grid will just fill up the whole space. THEN when the real grid is in the modal it takes up way more space than it should.

This change makes the grid wait up to 2 seconds for the element to have a width > 0 before it initializes the dimensions.

Note that this change also has a breaking change, which is that gridUtil can no longer try to get the width of hidden elements, which is the same as jQuery. Hidden elements really don't have any dimension.