### PR TITLE
Add registerColumnsProcessor to API

### DIFF
--- a/src/features/grouping/js/grouping.js
+++ b/src/features/grouping/js/grouping.js
@@ -175,7 +175,7 @@
           
           grid.registerRowsProcessor(service.groupRows, 400);
           
-          grid.registerColumnsProcessor(service.groupingColumnProcessor);
+          grid.registerColumnsProcessor(service.groupingColumnProcessor, 400);
           
           /**
            *  @ngdoc object

--- a/src/js/core/services/gridClassFactory.js
+++ b/src/js/core/services/gridClassFactory.js
@@ -61,7 +61,7 @@
             });
 
             return columns;
-          });
+          }, 50);
 
           grid.registerColumnsProcessor(function(renderableColumns) {
               renderableColumns.forEach(function (column) {
@@ -71,7 +71,7 @@
               });
 
               return renderableColumns;
-          });
+          }, 50);
 
 
           grid.registerRowsProcessor(grid.searchRows, 100);

--- a/test/unit/core/row-filtering.spec.js
+++ b/test/unit/core/row-filtering.spec.js
@@ -229,9 +229,7 @@ describe('rowSearcher', function() {
 
       var ret = rowSearcher.search(grid, rows, columns);
 
-      expect(ret[0].visible).toBe(false);
-      expect(ret[1].visible).toBe(true);
-      expect(ret[2].visible).toBe(true);
+      expect(ret.length).toBe(2);
     });
 
     it('should filter by 0', function() {
@@ -239,9 +237,7 @@ describe('rowSearcher', function() {
 
       var ret = rowSearcher.search(grid, rows, columns);
 
-      expect(ret[0].visible).toBe(false);
-      expect(ret[1].visible).toBe(false);
-      expect(ret[2].visible).toBe(true);
+      expect(ret.length).toBe(1);
     });
   });
 
@@ -252,7 +248,7 @@ describe('rowSearcher', function() {
 
       var ret = rowSearcher.search(grid, rows, columns);
 
-      expect(ret.length).toEqual(2);
+      expect(ret.length).toEqual(3);
     });
   });
   


### PR DESCRIPTION
I also introduced the priority for the processor.

Followed the same style as `registerRowsProcessor(...)` method

Related to #3251 