### PR TITLE
A variety of fixes

### DIFF
--- a/misc/tutorial/103_filtering.ngdoc
+++ b/misc/tutorial/103_filtering.ngdoc
@@ -187,13 +187,13 @@ this button.
     var gridTestUtils = require('../../test/e2e/gridTestUtils.spec.js');
     
     describe('first grid on the page, filtered by male by default', function() {
-      it('grid should have six visible columns', function () {
-        gridTestUtils.expectHeaderColumnCount( 'grid1', 6 );
+      it('grid should have seven visible columns', function () {
+        gridTestUtils.expectHeaderColumnCount( 'grid1', 7 );
       });
 
       it('filter on 4 columns, filter with greater than/less than on one, one with no filter, then one with one filter', function () {
         gridTestUtils.expectFilterBoxInColumn( 'grid1', 0, 1 );
-        gridTestUtils.expectFilterBoxInColumn( 'grid1', 1, 1 );
+        gridTestUtils.expectFilterSelectInColumn( 'grid1', 1, 1 );
         gridTestUtils.expectFilterBoxInColumn( 'grid1', 2, 0 );
         gridTestUtils.expectFilterBoxInColumn( 'grid1', 3, 1 );
         gridTestUtils.expectFilterBoxInColumn( 'grid1', 4, 1 );

--- a/misc/tutorial/121_grid_menu.ngdoc
+++ b/misc/tutorial/121_grid_menu.ngdoc
@@ -17,6 +17,8 @@ use i18n on this through the `gridMenuTitleFilter` setting)
 property `grid` (accessible through `this.grid`.  You can pass in your own context by supplying 
 the `context` property to your menu item. It will be accessible through `this.context`.
 - `leaveOpen`: by default false, if set to true the menu will be left open after the action
+- `order`: the order in the menu that you wish your item to be.  Columns are 300 -> 300 + numColumns * 2,
+  importer and exporter are 150 and 200 respectively 
 
 The exporter feature also adds menu items to this menu.  The `exporterMenuCsv` option is set
 to false, which suppresses csv export.  The 'export selected rows' option is only available
@@ -30,6 +32,14 @@ internationalization function that waits 1 second then prefixes each column with
 
 You can suppress the ability to show and hide columns by setting the gridOption `gridMenuShowHideColumns: false`,
 you can suppress the ability to hide individual columns by setting `enableHiding` on that columnDef to false.
+
+The gridMenu button is still a bit ugly.  If you have the skills to do so we'd welcome a PR that makes it pretty.
+In the meantime, you can override the height to fit with your application in your css:
+<pre>
+  .ui-grid-menu-button {
+    height: 31px;
+  }
+</pre>
 
 @example
 <example module="app">
@@ -59,7 +69,8 @@ you can suppress the ability to hide individual columns by setting `enableHiding
             title: 'Rotate Grid',
             action: function ($event) {
               this.grid.element.toggleClass('rotated');
-            }
+            },
+            order: 210
           }
         ],
         onRegisterApi: function( gridApi ){
@@ -67,7 +78,7 @@ you can suppress the ability to hide individual columns by setting `enableHiding
           
           // interval of zero just to allow the directive to have initialized
           $interval( function() {
-            gridApi.core.addToGridMenu( gridApi.grid, [{ title: 'Dynamic item'}]);
+            gridApi.core.addToGridMenu( gridApi.grid, [{ title: 'Dynamic item', order: 100}]);
           }, 0, 1);
           
           gridApi.core.on.columnVisibilityChanged( $scope, function( changedColumn ){

--- a/misc/tutorial/121_grid_menu.ngdoc
+++ b/misc/tutorial/121_grid_menu.ngdoc
@@ -139,6 +139,7 @@ you can suppress the ability to hide individual columns by setting `enableHiding
         gridTestUtils.expectHeaderCellValueMatch( 'grid1', 0, 'Name' );
         gridTestUtils.expectHeaderCellValueMatch( 'grid1', 1, 'Gender' );
 
+        gridTestUtils.unclickGridMenu( 'grid1');  // menu stays open if change columns
         gridTestUtils.clickGridMenuItem( 'grid1', 12 );  // there are some hidden menu items, this is company_show
         gridTestUtils.expectHeaderColumnCount( 'grid1', 3 );
         gridTestUtils.expectHeaderCellValueMatch( 'grid1', 0, 'Name' );

--- a/misc/tutorial/306_custom_filters.ngdoc
+++ b/misc/tutorial/306_custom_filters.ngdoc
@@ -179,6 +179,5 @@ a bootstrap dropdown.
   </file>
   <file name="scenario.js">
     var gridTestUtils = require('../../test/e2e/gridTestUtils.spec.js');
-    });
   </file>  
 </example>

--- a/misc/tutorial/307_external_sorting.ngdoc
+++ b/misc/tutorial/307_external_sorting.ngdoc
@@ -110,15 +110,15 @@ column however, so sorting by it has no effect.
 
       it('sort by name by clicking header', function () {
         gridTestUtils.clickHeaderCell( 'grid1', 0 );
-        gridTestUtils.expectCellValueMatch( 'grid1', 0, 0, 'Beryl Rice' );
-        gridTestUtils.expectCellValueMatch( 'grid1', 1, 0, 'Bruce Strong' );
+        gridTestUtils.expectCellValueMatch( 'grid1', 0, 0, 'Alexander Foley' );
+        gridTestUtils.expectCellValueMatch( 'grid1', 1, 0, 'Alisha Myers' );
       });
 
       it('reverse sort by name by clicking header', function () {
         gridTestUtils.clickHeaderCell( 'grid1', 0 );
         gridTestUtils.clickHeaderCell( 'grid1', 0 );
-        gridTestUtils.expectCellValueMatch( 'grid1', 0, 0, 'Wilder Gonzales' );
-        gridTestUtils.expectCellValueMatch( 'grid1', 1, 0, 'Valarie Atkinson' );
+        gridTestUtils.expectCellValueMatch( 'grid1', 0, 0, 'Yvonne Parsons' );
+        gridTestUtils.expectCellValueMatch( 'grid1', 1, 0, 'Woods Key' );
       });
       
       it('return to original sort by name by clicking header', function () {

--- a/misc/tutorial/401_AllFeatures.ngdoc
+++ b/misc/tutorial/401_AllFeatures.ngdoc
@@ -109,7 +109,7 @@ All features are enabled to get an idea of performance
         it('should not duplicate the menu options for pinning when resizing a column', function () {
           element( by.id('refreshButton') ).click();
           gridTestUtils.resizeHeaderCell( 'grid1', 1 );
-          gridTestUtils.expectVisibleColumnMenuItems( 'grid1', 1, 5)
+          gridTestUtils.expectVisibleColumnMenuItems( 'grid1', 1, 5);
         });
       });
   </file>

--- a/src/features/exporter/js/exporter.js
+++ b/src/features/exporter/js/exporter.js
@@ -479,7 +479,8 @@
               },
               shown: function() {
                 return this.grid.options.exporterMenuCsv && this.grid.options.exporterMenuAllData; 
-              }
+              },
+              order: 200
             },
             {
               title: i18nService.getSafeText('gridMenu.exporterVisibleAsCsv'),
@@ -488,7 +489,8 @@
               },
               shown: function() {
                 return this.grid.options.exporterMenuCsv; 
-              }
+              },
+              order: 201
             },
             {
               title: i18nService.getSafeText('gridMenu.exporterSelectedAsCsv'),
@@ -498,7 +500,8 @@
               shown: function() {
                 return this.grid.options.exporterMenuCsv &&
                        ( this.grid.api.selection && this.grid.api.selection.getSelectedRows().length > 0 ); 
-              }
+              },
+              order: 202
             },
             {
               title: i18nService.getSafeText('gridMenu.exporterAllAsPdf'),
@@ -507,7 +510,8 @@
               },
               shown: function() {
                 return this.grid.options.exporterMenuPdf && this.grid.options.exporterMenuAllData; 
-              }
+              },
+              order: 203
             },
             {
               title: i18nService.getSafeText('gridMenu.exporterVisibleAsPdf'),
@@ -516,7 +520,8 @@
               },
               shown: function() {
                 return this.grid.options.exporterMenuPdf; 
-              }
+              },
+              order: 204
             },
             {
               title: i18nService.getSafeText('gridMenu.exporterSelectedAsPdf'),
@@ -526,7 +531,8 @@
               shown: function() {
                 return this.grid.options.exporterMenuPdf &&
                        ( this.grid.api.selection && this.grid.api.selection.getSelectedRows().length > 0 ); 
-              }
+              },
+              order: 205
             }
           ]);
         },

--- a/src/features/importer/js/importer.js
+++ b/src/features/importer/js/importer.js
@@ -331,7 +331,8 @@
               templateUrl: 'ui-grid/importerMenuItemContainer',
               action: function ($event) {
                 this.grid.api.importer.importAFile( grid );
-              }
+              },
+              order: 150
             }
           ]);
         },

--- a/src/features/saveState/js/saveState.js
+++ b/src/features/saveState/js/saveState.js
@@ -20,7 +20,7 @@
    * <div doc-module-components="ui.grid.save-state"></div>
    */
 
-  var module = angular.module('ui.grid.saveState', ['ui.grid', 'ui.grid.selection', 'ui.grid.cellNav', 'ui.grid.grouping', 'ui.grid.pinning']);
+  var module = angular.module('ui.grid.saveState', ['ui.grid', 'ui.grid.selection', 'ui.grid.cellNav', 'ui.grid.grouping', 'ui.grid.pinning', 'ui.grid.treeView']);
 
   /**
    *  @ngdoc object
@@ -253,6 +253,16 @@
            * <br/>Defaults to true
            */
           gridOptions.savePinning = gridOptions.savePinning !== false;
+          /**
+           * @ngdoc object
+           * @name saveTreeView
+           * @propertyOf  ui.grid.saveState.api:GridOptions
+           * @description Save the treeView configuration.  If set to true and the 
+           * treeView feature is not enabled then does nothing.
+           * 
+           * <br/>Defaults to true
+           */
+          gridOptions.saveTreeView = gridOptions.saveTreeView !== false; 
         },
 
 
@@ -273,6 +283,7 @@
           savedState.scrollFocus = service.saveScrollFocus( grid );
           savedState.selection = service.saveSelection( grid );
           savedState.grouping = service.saveGrouping( grid );
+          savedState.treeView = service.saveTreeView( grid );
           
           return savedState;
         },
@@ -305,9 +316,11 @@
             service.restoreGrouping( grid, state.grouping );
           }
 
-          // refresh twice due to rendering issue.
-          //   specific case: save with column pinned left, hide that column, then restore
-          grid.refresh().then(function(){ grid.refresh(); });
+          if ( state.treeView ){
+            service.restoreTreeView( grid, state.treeView );
+          }
+
+          grid.refresh();
         },
         
         
@@ -417,11 +430,11 @@
          * @methodOf  ui.grid.saveState.service:uiGridSaveStateService
          * @description Saves the currently selected rows, if the selection feature is enabled
          * @param {Grid} grid the grid whose state we'd like to save
-         * @returns {object} the selection state ready to be saved
+         * @returns {array} the selection state ready to be saved
          */
         saveSelection: function( grid ){
           if ( !grid.api.selection || !grid.options.saveSelection ){
-            return {};
+            return [];
           }
 
           var selection = grid.api.selection.getSelectedGridRows().map( function( gridRow ) {
@@ -446,6 +459,23 @@
           }
 
           return grid.api.grouping.getGrouping( grid.options.saveGroupingExpandedStates );
+        },
+        
+        
+        /**
+         * @ngdoc function
+         * @name saveTreeView
+         * @methodOf  ui.grid.saveState.service:uiGridSaveStateService
+         * @description Saves the tree view state, if the tree feature is enabled
+         * @param {Grid} grid the grid whose state we'd like to save
+         * @returns {object} the tree view state ready to be saved
+         */
+        saveTreeView: function( grid ){
+          if ( !grid.api.treeView || !grid.options.saveTreeView ){
+            return {};
+          }
+
+          return grid.api.treeView.getTreeView();
         },
         
         
@@ -624,6 +654,23 @@
           }
           
           grid.api.grouping.setGrouping( groupingState );
+        },        
+        
+        /**
+         * @ngdoc function
+         * @name restoreTreeView
+         * @methodOf  ui.grid.saveState.service:uiGridSaveStateService
+         * @description Restores the tree view configuration, if the tree view feature
+         * is enabled.
+         * @param {Grid} grid the grid whose state we'd like to restore
+         * @param {object} treeViewState the tree view state ready to be restored
+         */
+        restoreTreeView: function( grid, treeViewState ){
+          if ( !grid.api.treeView || typeof(treeViewState) === 'undefined' || treeViewState === null || angular.equals(treeViewState, {}) ){
+            return;
+          }
+          
+          grid.api.treeView.setTreeView( treeViewState );
         },        
         
         /**

--- a/src/features/saveState/test/saveState.spec.js
+++ b/src/features/saveState/test/saveState.spec.js
@@ -4,6 +4,7 @@ describe('ui.grid.saveState uiGridSaveStateService', function () {
   var uiGridSelectionService;
   var uiGridCellNavService;
   var uiGridGroupingService;
+  var uiGridTreeViewService;
   var uiGridPinningService;
   var gridClassFactory;
   var grid;
@@ -16,12 +17,14 @@ describe('ui.grid.saveState uiGridSaveStateService', function () {
 
   beforeEach(inject(function (_uiGridSaveStateService_, _gridClassFactory_, _uiGridSaveStateConstants_,
                               _$compile_, _$rootScope_, _$document_, _uiGridSelectionService_,
-                              _uiGridCellNavService_, _uiGridGroupingService_, _uiGridPinningService_ ) {
+                              _uiGridCellNavService_, _uiGridGroupingService_, _uiGridTreeViewService_, 
+                              _uiGridPinningService_ ) {
     uiGridSaveStateService = _uiGridSaveStateService_;
     uiGridSaveStateConstants = _uiGridSaveStateConstants_;
     uiGridSelectionService = _uiGridSelectionService_;
     uiGridCellNavService = _uiGridCellNavService_;
     uiGridGroupingService = _uiGridGroupingService_;
+    uiGridTreeViewService = _uiGridTreeViewService_;
     uiGridPinningService = _uiGridPinningService_;
     gridClassFactory = _gridClassFactory_;
     $compile = _$compile_;
@@ -78,6 +81,7 @@ describe('ui.grid.saveState uiGridSaveStateService', function () {
         saveSelection: true,
         saveGrouping: true,
         saveGroupingExpandedStates: false,
+        saveTreeView: true,
         savePinning: true
       });
     });
@@ -95,6 +99,7 @@ describe('ui.grid.saveState uiGridSaveStateService', function () {
         saveSelection: false,
         saveGrouping: false,
         saveGroupingExpandedStates: true,
+        saveTreeView: false,
         savePinning: false
       };
       uiGridSaveStateService.defaultGridOptions(options);
@@ -109,6 +114,7 @@ describe('ui.grid.saveState uiGridSaveStateService', function () {
         saveSelection: false,
         saveGrouping: false,
         saveGroupingExpandedStates: true,
+        saveTreeView: false,
         savePinning: false
       });
     });    
@@ -649,6 +655,25 @@ describe('ui.grid.saveState uiGridSaveStateService', function () {
       uiGridSaveStateService.restoreGrouping( grid, undefined);
       
       expect(grid.api.grouping.setGrouping).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('restoreTreeView', function() {
+    beforeEach( function() {
+      grid.api.treeView = { setTreeView: function() {}};
+      spyOn( grid.api.treeView, 'setTreeView' ).andCallFake(function() {});
+    });
+    
+    it( 'calls setTreeView with config', function() {
+      uiGridSaveStateService.restoreTreeView( grid, { test: 'test' });
+      
+      expect(grid.api.treeView.setTreeView).toHaveBeenCalledWith( { test: 'test' });
+    });
+
+    it( 'doesn\'t call setTreeView when config missing', function() {
+      uiGridSaveStateService.restoreTreeView( grid, undefined);
+      
+      expect(grid.api.treeView.setTreeView).not.toHaveBeenCalled();
     });
   });
 

--- a/src/js/core/directives/ui-grid-menu-button.js
+++ b/src/js/core/directives/ui-grid-menu-button.js
@@ -196,6 +196,10 @@ angular.module('ui.grid')
         menuItems = menuItems.concat( service.showHideColumns( $scope ) );
       }
       
+      menuItems.sort(function(a, b){
+        return a.order - b.order;
+      });
+      
       return menuItems;
     },
     
@@ -236,7 +240,8 @@ angular.module('ui.grid')
       
       // add header for columns
       showHideColumns.push({
-        title: i18nService.getSafeText('gridMenu.columns')
+        title: i18nService.getSafeText('gridMenu.columns'),
+        order: 300
       });
       
       $scope.grid.options.gridMenuTitleFilter = $scope.grid.options.gridMenuTitleFilter ? $scope.grid.options.gridMenuTitleFilter : function( title ) { return title; };  
@@ -254,7 +259,8 @@ angular.module('ui.grid')
               return this.context.gridCol.colDef.visible === true || this.context.gridCol.colDef.visible === undefined;
             },
             context: { gridCol: $scope.grid.getColumn(colDef.name || colDef.field) },
-            leaveOpen: true
+            leaveOpen: true,
+            order: 300 + index * 2
           };
           service.setMenuItemTitle( menuItem, colDef, $scope.grid );
           showHideColumns.push( menuItem );
@@ -270,7 +276,8 @@ angular.module('ui.grid')
               return !(this.context.gridCol.colDef.visible === true || this.context.gridCol.colDef.visible === undefined);
             },
             context: { gridCol: $scope.grid.getColumn(colDef.name || colDef.field) },
-            leaveOpen: true
+            leaveOpen: true,
+            order: 300 + index * 2 + 1
           };
           service.setMenuItemTitle( menuItem, colDef, $scope.grid );
           showHideColumns.push( menuItem );

--- a/src/js/core/factories/Grid.js
+++ b/src/js/core/factories/Grid.js
@@ -672,8 +672,14 @@ angular.module('ui.grid')
    * @propertyOf ui.grid.class:GridOptions.columnDef
    * @description the type of the column, used in sorting.  If not provided then the 
    * grid will guess the type.  Add this only if the grid guessing is not to your
-   * satisfaction.  Refer to {@link ui.grid.service:GridUtil.guessType gridUtil.guessType} for
-   * a list of values the grid knows about.
+   * satisfaction.  One of:
+   * - 'string'
+   * - 'boolean'
+   * - 'number'
+   * - 'date'
+   * - 'object'
+   * - 'numberStr'
+   * Note that if you choose date, your dates should be in a javascript date type
    *
    */
   Grid.prototype.assignTypes = function(){

--- a/src/js/core/factories/GridColumn.js
+++ b/src/js/core/factories/GridColumn.js
@@ -173,7 +173,7 @@ angular.module('ui.grid')
       }
     };
 
-    var throttledUpdateAggregationValue = gridUtil.throttle(updateAggregationValue, self.grid.options.aggregationCalcThrottle);
+    var throttledUpdateAggregationValue = gridUtil.throttle(updateAggregationValue, self.grid.options.aggregationCalcThrottle, { trailing: true });
 
 
 

--- a/src/js/core/factories/GridOptions.js
+++ b/src/js/core/factories/GridOptions.js
@@ -303,9 +303,9 @@ angular.module('ui.grid')
        * @ngdoc property
        * @name aggregationCalcThrottle
        * @propertyOf ui.grid.class:GridOptions
-       * @description Default time in milliseconds to throttle aggregation calcuations, defaults to 1000ms
+       * @description Default time in milliseconds to throttle aggregation calcuations, defaults to 500ms
        */
-      baseOptions.aggregationCalcThrottle = typeof(baseOptions.aggregationCalcThrottle) !== "undefined" ? baseOptions.aggregationCalcThrottle : 1000;
+      baseOptions.aggregationCalcThrottle = typeof(baseOptions.aggregationCalcThrottle) !== "undefined" ? baseOptions.aggregationCalcThrottle : 500;
   
       /**
        * @ngdoc property

--- a/src/js/core/services/ui-grid-util.js
+++ b/src/js/core/services/ui-grid-util.js
@@ -403,11 +403,11 @@ module.service('gridUtil', ['$log', '$window', '$document', '$http', '$templateC
      *
      * @param {string/number/bool/object} item variable to examine
      * @returns {string} one of the following
-     * 'string'
-     * 'boolean'
-     * 'number'
-     * 'date'
-     * 'object'
+     * - 'string'
+     * - 'boolean'
+     * - 'number'
+     * - 'date'
+     * - 'object'
      */
     guessType : function (item) {
       var itemType = typeof(item);

--- a/src/js/core/services/ui-grid-util.js
+++ b/src/js/core/services/ui-grid-util.js
@@ -169,8 +169,8 @@ var uidPrefix = 'uiGrid-';
  *  
  *  @description Grid utility functions
  */
-module.service('gridUtil', ['$log', '$window', '$document', '$http', '$templateCache', '$timeout', '$injector', '$q', '$interpolate', 'uiGridConstants',
-  function ($log, $window, $document, $http, $templateCache, $timeout, $injector, $q, $interpolate, uiGridConstants) {
+module.service('gridUtil', ['$log', '$window', '$document', '$http', '$templateCache', '$timeout', '$interval', '$injector', '$q', '$interpolate', 'uiGridConstants',
+  function ($log, $window, $document, $http, $templateCache, $timeout, $interval, $injector, $q, $interpolate, uiGridConstants) {
   var s = {
 
     getStyles: getStyles,
@@ -1078,6 +1078,8 @@ module.service('gridUtil', ['$log', '$window', '$document', '$http', '$templateC
    * Adapted from debounce function (above)
    * Potential keys for Params Object are:
    *    trailing (bool) - whether to trigger after throttle time ends if called multiple times
+   * Updated to use $interval rather than $timeout, as protractor (e2e tests) is able to work with $interval,
+   * but not with $timeout
    * @example
    * <pre>
    * var throttledFunc =  gridUtil.throttle(function(){console.log('throttled');}, 500, {trailing: true});
@@ -1093,7 +1095,7 @@ module.service('gridUtil', ['$log', '$window', '$document', '$http', '$templateC
     function runFunc(endDate){
       lastCall = +new Date();
       func.apply(context, args);
-      $timeout(function(){ queued = null; }, 0);
+      $interval(function(){ queued = null; }, 0, 1);
     }
 
     return function(){
@@ -1106,7 +1108,7 @@ module.service('gridUtil', ['$log', '$window', '$document', '$http', '$templateC
           runFunc();
         }
         else if (options.trailing){
-          queued = $timeout(runFunc, wait - sinceLast);
+          queued = $interval(runFunc, wait - sinceLast, 1);
         }
       }
     };

--- a/src/less/menu.less
+++ b/src/less/menu.less
@@ -2,10 +2,11 @@
   z-index: 2;
   position: absolute;
   right: 0;
+  top: 0;
   background: @headerBackgroundColor;
   border: @gridBorderWidth solid @borderColor;
   cursor: pointer;
-  min-height: 27px;
+  height: 31px;
   font-weight: normal;
 }
 
@@ -16,7 +17,7 @@
 .ui-grid-menu-button .ui-grid-menu {
   right: 0;
   .ui-grid-menu-mid {
-    overflow-y: scroll;
+    overflow: scroll;
     max-height: 300px;
     border: @gridBorderWidth solid @borderColor;
   }
@@ -25,7 +26,6 @@
 .ui-grid-menu {
   z-index: 2; // So it shows up over grid canvas
   position: absolute;
-  overflow: hidden;
   padding: 0 10px 20px 10px;
   cursor: pointer;
   box-sizing: content-box;

--- a/src/templates/ui-grid/ui-grid-header.html
+++ b/src/templates/ui-grid/ui-grid-header.html
@@ -10,6 +10,5 @@
       </div>
 
     </div>
-    <div ui-grid-menu></div>
   </div>
 </div>

--- a/test/e2e/gridTestUtils.spec.js
+++ b/test/e2e/gridTestUtils.spec.js
@@ -684,7 +684,7 @@ module.exports = {
   *
   * @example
   * <pre>
-  *   gridTestUtils.clickVisibleGridMenuItem('myGrid', 9);
+  *   gridTestUtils.clickGridMenuItem('myGrid', 9);
   * </pre>
   *
   */
@@ -693,5 +693,25 @@ module.exports = {
     gridMenuButton.click();
 
     gridMenuButton.element( by.repeater('item in menuItems').row( itemNumber) ).click();
-  }
+  },
+  
+  /**
+  * @ngdoc method
+  * @methodOf ui.grid.e2eTestLibrary.api:gridTest
+  * @name unclickGridMenu
+  * @description Closes the grid menu if it's open (opens it if it's closed).
+  * The grid menu stays open when you change column visibility, it sometimes needs
+  * to be closed again.
+  * @param {string} gridId the id of the grid that you want to inspect
+  *
+  * @example
+  * <pre>
+  *   gridTestUtils.unclickGridMenu('myGrid');
+  * </pre>
+  *
+  */
+  unclickGridMenu: function( gridId ) {
+    var gridMenuButton = this.getGrid( gridId ).element( by.css ( '.ui-grid-menu-button' ) );
+    gridMenuButton.click();
+  }  
 };

--- a/test/e2e/gridTestUtils.spec.js
+++ b/test/e2e/gridTestUtils.spec.js
@@ -537,6 +537,29 @@ module.exports = {
   /**
   * @ngdoc method
   * @methodOf ui.grid.e2eTestLibrary.api:gridTest
+  * @name expectFilterSelectInColumn
+  * @description Checks that a filter select dropdown exists in the specified column
+  * @param {string} gridId the id of the grid that you want to inspect
+  * @param {integer} colNumber the number of the column (within the visible columns)
+  * that you want to verify the filter select is in
+  * @param {integer} count the number filter selects you expect - 0 meaning none, 1 meaning
+  * a standard filter, 2 meaning a numerical filter with greater than / less than.
+  *
+  * @example
+  * <pre>
+  *   gridTestUtils.expectFilterSelectInColumn('myGrid', 0, 0);
+  * </pre>
+  *
+  */
+  expectFilterSelectInColumn: function( gridId, colNumber, count ) {
+    var headerCell = this.headerCell( gridId, colNumber);
+
+    expect( headerCell.all( by.css( '.ui-grid-filter-select' ) ).count() ).toEqual(count);
+  },
+
+  /**
+  * @ngdoc method
+  * @methodOf ui.grid.e2eTestLibrary.api:gridTest
   * @name cancelFilterInColumn
   * @description Cancels the filter in a column
   * @param {string} gridId the id of the grid that you want to inspect

--- a/test/unit/core/factories/GridOptions.spec.js
+++ b/test/unit/core/factories/GridOptions.spec.js
@@ -36,7 +36,7 @@ describe('GridOptions factory', function () {
         scrollThreshold: 4,
         excessColumns: 4,
         horizontalScrollThreshold: 2,
-        aggregationCalcThrottle: 1000,
+        aggregationCalcThrottle: 500,
         wheelScrollThrottle: 70,
         scrollDebounce: 300,
         enableSorting: true,

--- a/test/unit/core/services/ui-grid-util.spec.js
+++ b/test/unit/core/services/ui-grid-util.spec.js
@@ -53,7 +53,7 @@ describe('ui.grid.utilService', function() {
       x++;
     };
 
-    it('prevents multiple function calls', inject(function ($timeout) {
+    it('prevents multiple function calls', inject(function ($interval) {
       x = 0;
 
       var throttledFunc = gridUtil.throttle(func, 10);
@@ -61,11 +61,11 @@ describe('ui.grid.utilService', function() {
       throttledFunc();
       throttledFunc();
       expect(x).toEqual(1);
-      $timeout.flush();
+      $interval.flush(15);
       expect(x).toEqual(1);
     }));
 
-    it('queues a final event if trailing param is truthy', inject(function ($timeout) {
+    it('queues a final event if trailing param is truthy', inject(function ($interval) {
       x = 0;
 
       var throttledFunc = gridUtil.throttle(func, 10, {trailing: true});
@@ -73,7 +73,7 @@ describe('ui.grid.utilService', function() {
       throttledFunc();
       throttledFunc();
       expect(x).toEqual(1);
-      $timeout.flush();
+      $interval.flush(15);
       expect(x).toEqual(2);
     }));
 


### PR DESCRIPTION
Fix #3236: doco on columnDef types
Fix footer: aggregation wasn't running on first load, changed the throttle to do one last call afterwards, changed throttle to $interval rather than $timeout to avoid breakage on e2e tests (protractor doesn't like $timeout)
Enh e2e tests: added a check for filter dropdowns
Fix e2e tests: fixed a variety of breakage in the e2e tests
Enh gridMenu: support for ordering on menu items, they were not deterministic and therefore sometimes in different orders
Enh saveState: allow saving of treeView state