### PR TITLE
Applying sortInfo to lazy loaded columns

### DIFF
--- a/src/directives/ng-grid.js
+++ b/src/directives/ng-grid.js
@@ -47,6 +47,10 @@
                                 $scope.columns = [];
                                 grid.config.columnDefs = a;
                                 grid.buildColumns();
+                                if (grid.config.sortInfo.fields.length > 0) {
+                                    grid.sortColumnsInit();
+                                    $scope.$emit('ngGridEventSorted', grid.config.sortInfo);
+                                }
                                 grid.eventProvider.assignEvents();
                                 domUtilityService.RebuildGrid($scope, grid);
                             }, true));


### PR DESCRIPTION
If columns are lazy loaded, and sortInfo is populated prior to the columns loading, the sortInfo is not applied to the columns. Fixing that.

The following is a plunker that demonstrates the issue:
http://plnkr.co/edit/jMX4JAE6I3kTCcnEIeaZ?p=preview