### PR TITLE
Fix(less): removed importants in favor of higher priority selector #3281

### DIFF
--- a/src/features/selection/less/selection.less
+++ b/src/features/selection/less/selection.less
@@ -1,7 +1,7 @@
 @import '../../../less/variables';
 
-.ui-grid-row-selected > [ui-grid-row] > .ui-grid-cell {
-  background-color: @rowSelected !important;
+.ui-grid-row.ui-grid-row-selected > [ui-grid-row] > .ui-grid-cell {
+  background-color: @rowSelected;
 }
 
 .ui-grid-disable-selection {

--- a/src/less/cell.less
+++ b/src/less/cell.less
@@ -36,8 +36,8 @@
   display: none;
 }
 
-.ui-grid-row-header-cell {
-  background-color: #F0F0EE !important;
+.ui-grid-row .ui-grid-cell.ui-grid-row-header-cell {
+  background-color: @rowHeaderCell;
   border-bottom: solid @gridBorderWidth @borderColor;
 }
 

--- a/src/less/variables.less
+++ b/src/less/variables.less
@@ -41,7 +41,7 @@
 
 
 // TODO: color for menu background
-
+@rowHeaderCell: #F0F0EE;
 @rowSelected: #C9DDE1;
 @rowSavingForeground: #848484;
 @rowErrorForeground: #FF0000;


### PR DESCRIPTION
Fix for [#3281](https://github.com/angular-ui/ng-grid/issues/3281)

'!important' in cell.less & selection.less

In addition to updating the css selectors and removing !importants, I added a less variable for the .ui-grid-row-header-cell background color