### PR TITLE
Add Grid.prototype.clearAllFilters() method.

### DIFF
--- a/src/js/core/factories/Grid.js
+++ b/src/js/core/factories/Grid.js
@@ -417,7 +417,19 @@ angular.module('ui.grid')
      * 
      */
     self.api.registerMethod( 'core', 'notifyDataChange', this.notifyDataChange );
-    
+
+    /**
+     * @ngdoc method
+     * @name clearAllFilters
+     * @methodOf ui.grid.core.api:PublicApi
+     * @description Clears all filters and optionally refreshes the visible rows.
+     * @params {object} refreshRows Defaults to true.
+     * @params {object} clearConditions Defaults to false.
+     * @params {object} clearFlags Defaults to false.
+     * @returns {promise} If `refreshRows` is true, returns a promise of the rows refreshing.
+     */
+    self.api.registerMethod('core', 'clearAllFilters', this.clearAllFilters);
+
     self.registerDataChangeCallback( self.columnRefreshCallback, [uiGridConstants.dataChange.COLUMN]);
     self.registerDataChangeCallback( self.processRowsCallback, [uiGridConstants.dataChange.EDIT]);
 
@@ -2381,6 +2393,47 @@ angular.module('ui.grid')
       }
       return this.scrollToIfNecessary(gridRow, gridCol);
     };
+
+  /**
+   * @ngdoc function
+   * @name clearAllFilters
+   * @methodOf ui.grid.class:Grid
+   * @description Clears all filters and optionally refreshes the visible rows.
+   * @params {object} refreshRows Defaults to true.
+   * @params {object} clearConditions Defaults to false.
+   * @params {object} clearFlags Defaults to false.
+   * @returns {promise} If `refreshRows` is true, returns a promise of the rows refreshing.
+   */
+  Grid.prototype.clearAllFilters = function clearAllFilters(refreshRows, clearConditions, clearFlags) {
+    // Default `refreshRows` to true because it will be the most commonly desired behaviour.
+    if (refreshRows === undefined) {
+      refreshRows = true;
+    }
+    if (clearConditions === undefined) {
+      clearConditions = false;
+    }
+    if (clearFlags === undefined) {
+      clearFlags = false;
+    }
+
+    this.columns.forEach(function(column) {
+      column.filters.forEach(function(filter) {
+        filter.term = undefined;
+
+        if (clearConditions) {
+          filter.condition = undefined;
+        }
+
+        if (clearFlags) {
+          filter.flags = undefined;
+        }
+      });
+    });
+
+    if (refreshRows) {
+      return this.refreshRows();
+    }
+  };
 
 
       // Blatantly stolen from Angular as it isn't exposed (yet? 2.0?)

--- a/test/unit/core/factories/Grid.spec.js
+++ b/test/unit/core/factories/Grid.spec.js
@@ -831,4 +831,76 @@ describe('Grid factory', function () {
       });
     });
   });
+
+  describe('clearAllFilters', function() {
+    it('should clear all filter terms from all columns', function() {
+      grid.columns = [
+        {filters: [{term: 'A'}, {term: 'B'}]},
+        {filters: [{term: 'C'}]},
+        {filters: []}
+      ];
+
+      grid.clearAllFilters();
+
+      expect(grid.columns[0].filters).toEqual([{}, {}]);
+      expect(grid.columns[1].filters).toEqual([{}]);
+      expect(grid.columns[2].filters).toEqual([]);
+    });
+
+    it('should call grid.refreshRows() if the refreshRows parameter is true', function() {
+      spyOn(grid, 'refreshRows');
+
+      grid.clearAllFilters(true);
+
+      expect(grid.refreshRows).toHaveBeenCalled();
+    });
+
+    it('should not call grid.refreshRows() if the refreshRows parameter is false', function() {
+      spyOn(grid, 'refreshRows');
+
+      grid.clearAllFilters(false);
+
+      expect(grid.refreshRows).not.toHaveBeenCalled();
+    });
+
+    it('should clear filter conditions from all columns if the clearConditions parameter is true', function() {
+      grid.columns = [
+        {filters: [{condition: 'a value'}]}
+      ];
+
+      grid.clearAllFilters(undefined, true, undefined);
+
+      expect(grid.columns[0].filters[0].condition).toBeUndefined();
+    });
+
+    it('should not clear filter conditions from any column if the clearConditions parameter is false', function() {
+      grid.columns = [
+        {filters: [{condition: 'a value'}]}
+      ];
+
+      grid.clearAllFilters(undefined, false, undefined);
+
+      expect(grid.columns[0].filters[0].condition).toBe('a value');
+    });
+
+    it('should clear filter flags from all columns if the clearFlags parameter is true', function() {
+      grid.columns = [
+        {filters: [{flags: 'a value'}]}
+      ];
+
+      grid.clearAllFilters(undefined, undefined, true);
+
+      expect(grid.columns[0].filters[0].flags).toBeUndefined();
+    });
+
+    it('should not clear filter flags from any column if the clearFlags parameter is false', function() {
+      grid.columns = [
+        {filters: [{flags: 'a value'}]}
+      ];
+
+      grid.clearAllFilters(undefined, undefined, false);
+
+      expect(grid.columns[0].filters[0].flags).toBe('a value');
+    });
+  });
 });


### PR DESCRIPTION
I had a use-case where I needed a button that clears all filters applied to all columns. This pull request adds a method to the Grid class, `clearAllFilters()`, which does that.