### PR TITLE
For SELECT filter ng-options, use track by instead of selectAs

### DIFF
--- a/src/js/core/services/rowSearcher.js
+++ b/src/js/core/services/rowSearcher.js
@@ -77,6 +77,13 @@ module.service('rowSearcher', ['gridUtil', 'uiGridConstants', function (gridUtil
     }
 
     var term = rowSearcher.getTerm(filter);
+
+    // A searchOption value could be an object so it is better to user angular.equals instead of a regex.
+    if (angular.isObject(term) && term.value && !angular.isDefined(filter.condition)) {
+      return function(searchTerm, cellValue) {
+        return angular.equals(searchTerm, cellValue);
+      }
+    }
     
     if (/\*/.test(term)) {
       var regexpFlags = '';
@@ -178,7 +185,8 @@ module.service('rowSearcher', ['gridUtil', 'uiGridConstants', function (gridUtil
     var conditionType = typeof(filter.condition);
 
     // Term to search for.
-    var term = filter.term;
+    // Exctract the term.value for selectOptions since ng-options track by returns the entire object.
+    var term = angular.isObject(filter.term) && filter.term.value ? filter.term.value : filter.term;
 
     // Get the column value for this row
     var value = grid.getCellValue(row, column);

--- a/src/templates/ui-grid/ui-grid-filter.html
+++ b/src/templates/ui-grid/ui-grid-filter.html
@@ -8,7 +8,7 @@
   </div>
   
   <div ng-if="colFilter.type === 'select'">
-    <select class="ui-grid-filter-select" ng-model="colFilter.term" ng-attr-placeholder="{{colFilter.placeholder || ''}}" ng-options="option.value as option.label for option in colFilter.selectOptions">
+    <select class="ui-grid-filter-select" ng-model="colFilter.term" ng-attr-placeholder="{{colFilter.placeholder || ''}}" ng-options="option.label for option in colFilter.selectOptions track by option.label">
       <option value=""></option>
     </select>
 


### PR DESCRIPTION
This fixes the dropdown view when initializing the dropdown value’s "term" or when setting the "term" value programmatically such as during table restore state.

For an example of how it affects ui-grid, please see this [plnkr](http://plnkr.co/edit/h95AeH?p=preview).  For the plnkr, I've modified the Company field to be an object instead of a string and display multiple properties for that object in the column cells.  I want an initial filter selection to be set so I set the term to be "{name: 'Oulu Incorporated', country: 'US'}".  Although the table is properly filtered, the filter dropdown is blank.  This is because Angular's ng-options determines that the term is not the identical reference to the option value.  This problem is also encountered when doing a restoreState.  Technically, we could fix this by adding a track by expression but AngularJS does not fully support "track by" and "selectAs" as per https://github.com/angular/angular.js/issues/6564.  Angular core team does not appear to be planning to fix this.

A workaround is described in that ticket, [plnkr](http://plnkr.co/edit/tevxjW?p=preview).  That workaround was used for this second [plnkr](http://plnkr.co/edit/WNrW9r?p=preview) and contains the fix in this pull request.  Note that the initial value shows up in the dropdown, the table is properly filtered on that initial value, and that other dropdown options work as well.

Please note that this is a breaking fix for existing users of dropdown SELECT filters if they are using cell values that are objects and not strings.  The initializing term must be the entire selectOption object instead of just the value portion.  Also, when comparing the searchTerm to the cellValue in the condition function, the searchTerm.value must be used instead of just searchTerm.