### PR TITLE
Fixed to handle undefined field when grouping

### DIFF
--- a/src/classes/rowFactory.js
+++ b/src/classes/rowFactory.js
@@ -195,7 +195,7 @@
                 var col = filterCols(cols, group)[0];
 
                 var val = $utils.evalProperty(model, group);
-                val = (val === '' || val === null) ? 'null' : val.toString();
+                val = (val === '' || val === null || val === undefined) ? 'null' : val.toString();
                 if (!ptr[val]) {
                     ptr[val] = {};
                 }


### PR DESCRIPTION
Fix: Commit # 24155ad breaks group by field if the field is missing in any of the row. This is because of val.toString() which doesn't work on undefined.

http://plnkr.co/edit/9TaFbiAIsVSAObPpcgO4?p=preview

Should be changed to:

<pre>val = (val === "" || val === null || val === undefined) ? 'null' : val.toString();</pre>