### PR TITLE
fix(clearThisRowInvisible) not using parameter reason

### DIFF
--- a/src/js/core/factories/GridRow.js
+++ b/src/js/core/factories/GridRow.js
@@ -176,7 +176,7 @@ angular.module('ui.grid')
    */
   GridRow.prototype.clearThisRowInvisible = function ( reason, fromRowsProcessor ) {
     if (typeof(this.invisibleReason) !== 'undefined' ) {
-      delete this.invisibleReason.user;
+      delete this.invisibleReason[reason];
     }
     this.evaluateRowVisibility( fromRowsProcessor );
   };


### PR DESCRIPTION
Not sure if intended but clearThisRowInvisible is not using the parameter "reason" when deleting the "invisible reason" but it always deletes the hardcoded parameter "user". 
This shouldn't change any other behavior since ui-grid internal functions call this function only with the parameter "user" but it will fix any unexpected behavior when using this function with a custom invisible reason

Haven't put a check if the value exists since "delete" fails silently in that case