### PR TITLE
pass context to getCellValue function expressions, and fix #3435

### DIFF
--- a/misc/tutorial/106_binding.ngdoc
+++ b/misc/tutorial/106_binding.ngdoc
@@ -5,12 +5,9 @@
 UI-Grid supports complex object binding in the colDef.field.
 
 This tutorial shows two-way binding to properties with special characters, array element, nested property, and function.
+Angular expressions will have 'row' and 'col' objects available on scope within the grid cell.
 
-Note that a function can not be edited. Functions will receive a `context` object, with access to both the current row and column, as the only argument.
-    <pre>
-      {row: GridRow,
-      column: GridColumn}
-    </pre>
+Note that a function can not be edited.
 
 In your custom cellTemplates, you can use:
 <br/>
@@ -41,8 +38,8 @@ MODEL\_COL\_FIELD which will be replaced with row.entity.field.  Use MODEL\_COL\
                                "friends": ["friend0"],
                                "address": {street:"301 Dove Ave", city:"Laurel", zip:"39565"},
                                "getZip" : function() {return this.address.zip;},
-                               "getTown" : function(context) {
-                                 return context.col.displayName + ': '+ this.address.city + ', ' + country;
+                               "getTown" : function(col) {
+                                 return col.displayName + ': '+ this.address.city + ', ' + country;
                                }
                            }
                        ]

--- a/misc/tutorial/106_binding.ngdoc
+++ b/misc/tutorial/106_binding.ngdoc
@@ -6,7 +6,11 @@ UI-Grid supports complex object binding in the colDef.field.
 
 This tutorial shows two-way binding to properties with special characters, array element, nested property, and function.
 
-Note that a function can not be edited.
+Note that a function can not be edited. Functions will receive a `context` object, with access to both the current row and column, as the only argument.
+    <pre>
+      {row: GridRow,
+      column: GridColumn}
+    </pre>
 
 In your custom cellTemplates, you can use:
 <br/>
@@ -23,19 +27,23 @@ MODEL\_COL\_FIELD which will be replaced with row.entity.field.  Use MODEL\_COL\
 
     app.controller('MainCtrl', ['$scope', function ($scope) {
 
+    var country = 'USA'
     $scope.gridOptions = {
             enableSorting: true,
             columnDefs: [
               { name:'firstName', field: 'first-name' },
               { name:'1stFriend', field: 'friends[0]' },
-              { name:'city', field: 'address.city'},
+              { name:'getCity', displayName: 'Town', field: 'getTown(context)', enableCellEdit:false},
               { name:'getZip', field: 'getZip()', enableCellEdit:false}
             ],
             data : [      {
                                "first-name": "Cox",
                                "friends": ["friend0"],
                                "address": {street:"301 Dove Ave", city:"Laurel", zip:"39565"},
-                               "getZip" : function() {return this.address.zip;}
+                               "getZip" : function() {return this.address.zip;},
+                               "getTown" : function(context) {
+                                 return context.col.displayName + ': '+ this.address.city + ', ' + country;
+                               }
                            }
                        ]
           };
@@ -49,7 +57,7 @@ MODEL\_COL\_FIELD which will be replaced with row.entity.field.  Use MODEL\_COL\
   </file>
   <file name="main.css">
     .grid {
-      width: 500px;
+      width: 800px;
       height: 250px;
     }
   </file>

--- a/src/features/grouping/js/grouping.js
+++ b/src/features/grouping/js/grouping.js
@@ -168,6 +168,9 @@
           grid.grouping.rowExpandedStates = {};
 
           service.defaultGridOptions(grid.options);
+          if (grid.options.flatEntityAccess){
+            throw  new Error('uiGrid grouping initialization failed. Grouping does not support the flatEntityAccess option.');
+          }
           
           grid.registerRowsProcessor(service.groupRows, 400);
           
@@ -605,7 +608,36 @@
             col.menuItems.push(aggregateRemove);
           }
         },
-        
+
+         /**
+         * @ngdoc function
+         * @name getGroupingAggregatedValue
+         * @methodOf  ui.grid.grouping.service:uiGridGroupingService
+         * @description A function to be used in the expression for cellValue, which allows the grouping
+         * feature to determine whether to display an aggegated value or the a value from the data.
+         * This is needed to deal with the case where we have two instances of a column, which use
+         * different aggregation typs.
+         *
+         * @param {object} context the context passed by grid.getCellValue
+         * @returns {object} the cellValue to be displayed
+         */
+        getGroupingAggregatedValue: function ( context ){
+          if ( !context.row.groupHeader){
+            return context.row.entity[context.col.groupingOriginalField];
+          }
+
+          var aggregations = context.row.aggregations[context.col.groupingOriginalField];
+          if ( typeof context.col.grouping !== 'undefined' && context.col.grouping.groupPriority >= 0 ){
+            return context.row.entity[context.col.groupingOriginalField];
+          }
+          if ( typeof context.row.aggregations[context.col.groupingOriginalField] === 'undefined' ){
+            return null;
+          }
+          if (!context.col.groupingSuppressAggregationText){
+            return i18nService.get().aggregation[context.col.grouping.aggregation] + aggregations[context.col.grouping.aggregation];
+          }
+          return aggregations[context.col.grouping.aggregation];
+         },
         
         
         /**
@@ -621,6 +653,13 @@
          */
         groupingColumnProcessor: function( columns, rows ) {
           var grid = this;
+
+          rows.forEach( function( row, index){
+            if ( typeof row.entity.$$getAggregatedValue === 'undefined' ){
+              row.entity.$$getAggregatedValue = service.getGroupingAggregatedValue;
+            }
+          });
+
           columns.forEach( function(column, index){
             // position used to make stable sort in moveGroupColumns
             column.groupingPosition = index;
@@ -641,7 +680,11 @@
               indent = indent > 0 ? indent : 0;
               column.width = grid.options.groupingRowHeaderBaseWidth + indent; 
             }
-            
+
+            if ( typeof column.groupingOriginalField === 'undefined' || column.field === column.groupingOriginalField ){
+              column.groupingOriginalField = column.field;
+              column.field = '$$getAggregatedValue(context)';
+            }
           });
           
           columns = service.moveGroupColumns(this, columns, rows);
@@ -1160,7 +1203,7 @@
           for (var i = 0; i < renderableRows.length; i++ ){
             var row = renderableRows[i];
             
-            groupingProcessingState.forEach( updateProcessingState);
+            groupingProcessingState.forEach( updateProcessingState );
             
             service.setVisibility( grid, row, groupingProcessingState );
           }
@@ -1235,10 +1278,11 @@
           // get all the grouping
           grid.columns.forEach( function(column, columnIndex){
             if ( column.grouping ){
+              var groupingField = column.groupingOriginalField || column.field;
               if ( typeof(column.grouping.groupPriority) !== 'undefined' && column.grouping.groupPriority >= 0){
-                groupArray.push({ field: column.field, col: column, groupPriority: column.grouping.groupPriority, grouping: column.grouping });  
+                groupArray.push({ field: groupingField, col: column, groupPriority: column.grouping.groupPriority, grouping: column.grouping });
               } else if ( column.grouping.aggregation ){
-                aggregateArray.push({ field: column.field, col: column, aggregation: column.grouping.aggregation });
+                aggregateArray.push({ field: groupingField, col: column, aggregation: column.grouping.aggregation });
               }
             }
           });
@@ -1285,9 +1329,10 @@
           var fieldName = groupingProcessingState[stateIndex].fieldName;
           var col = groupingProcessingState[stateIndex].col;
 
-          // TODO: can't just use entity like this, have to use get cell value, need col for that
           var newValue = grid.getCellValue(renderableRows[rowIndex], col);
           headerRow.entity[fieldName] = newValue;
+          headerRow.entity.$$getAggregatedValue = service.getGroupingAggregatedValue;
+          headerRow.aggregations = {};
           headerRow.groupLevel = stateIndex;
           headerRow.groupHeader = true;
           headerRow.internalRow = true;
@@ -1341,21 +1386,16 @@
               if (aggregation.fieldName === uiGridGroupingConstants.aggregation.FIELD){
                 // running total to include in the groupHeader
                 processingState.currentGroupHeader.entity[processingState.fieldName] = processingState.currentValue + ' (' + aggregation.value + ')';
-                aggregation.value = null; 
               } else {
-                if (aggregation.col.groupingSuppressAggregationText){
-                  processingState.currentGroupHeader.entity[aggregation.fieldName] = aggregation.value;
-                } else {
-                  processingState.currentGroupHeader.entity[aggregation.fieldName] = i18nService.get().aggregation[aggregation.type] + aggregation.value;
+                if ( typeof processingState.currentGroupHeader.aggregations[aggregation.fieldName] === 'undefined'){
+                  processingState.currentGroupHeader.aggregations[aggregation.fieldName] = {};
                 }
-                aggregation.value = null;
-                if ( aggregation.sum ){
-                  aggregation.sum = null;
-                }
-                if ( aggregation.count ){
-                  aggregation.count = null;
-                }
+                processingState.currentGroupHeader.aggregations[aggregation.fieldName][aggregation.type] = aggregation.value;
               }
+
+              delete aggregation.sum;
+              delete aggregation.count;
+              aggregation.value = null;
             });
           }
           processingState.currentGroupHeader = null;
@@ -1456,9 +1496,9 @@
                   }
                   break;
                 case uiGridGroupingConstants.aggregation.AVG:
-                  aggregation.count++;
+                  aggregation.count = aggregation.count ? aggregation.count + 1 : 1;
                   if (!isNaN(numValue)){
-                    aggregation.sum += numValue;
+                    aggregation.sum = aggregation.sum ? aggregation.sum + numValue : numValue;
                   }
                   aggregation.value = aggregation.sum / aggregation.count;
                   break;

--- a/src/features/grouping/test/grouping.spec.js
+++ b/src/features/grouping/test/grouping.spec.js
@@ -409,12 +409,19 @@ describe('ui.grid.grouping uiGridGroupingService', function () {
   describe('insertGroupHeader', function() {
     it('inserts a header in the middle', function() {
       spyOn(gridClassFactory, 'rowTemplateAssigner').andCallFake( function() {});
-      var headerRow1 = new GridRow( {}, null, grid );
-      var headerRow2 = new GridRow( {}, null, grid );
-      var headerRow3 = new GridRow( {}, null, grid );
+      var headerRow1 = new GridRow( {$$getAggregatedValue: uiGridGroupingService.getGroupingAggregatedValue}, null, grid );
 
+      var headerRow2 = new GridRow( {$$getAggregatedValue: uiGridGroupingService.getGroupingAggregatedValue}, null, grid );
+
+      var headerRow3 = new GridRow( {$$getAggregatedValue: uiGridGroupingService.getGroupingAggregatedValue}, null, grid );
+
+      headerRow1.aggregations = {};
       headerRow1.expandedState = { state: uiGridGroupingConstants.EXPANDED };
+
+      headerRow2.aggregations = {};
       headerRow2.expandedState = { state: uiGridGroupingConstants.COLLAPSED };
+
+      headerRow3.aggregations = {};
        
       var processingStates = [
         { 
@@ -455,18 +462,18 @@ describe('ui.grid.grouping uiGridGroupingService', function () {
       uiGridGroupingService.insertGroupHeader(grid, grid.rows, 3, processingStates, 1);
       
       expect( grid.rows.length ).toEqual(11, 'extra row created');
-      expect( grid.rows[3].entity).toEqual({col2: 'c_3'}, 'no aggregations yet, only the group title');
-      expect( grid.rows[3].entity).toEqual({col2: 'c_3'}, 'no aggregations yet, only the group title');
-      expect(headerRow2.entity).toEqual({ agg1: 'max: x', agg2: 'min: 22' });
-      expect(headerRow3.entity).toEqual({ agg1: 'max: y', agg2: 'min: 13' });
+      expect( grid.rows[3].entity).toEqual({col2: 'c_3', $$getAggregatedValue: uiGridGroupingService.getGroupingAggregatedValue}, 'no aggregations yet, only the group title');
+      expect( grid.rows[3].entity).toEqual({col2: 'c_3', $$getAggregatedValue: uiGridGroupingService.getGroupingAggregatedValue}, 'no aggregations yet, only the group title');
+      expect(headerRow2.aggregations).toEqual({ agg1: {max: 'x'}, agg2: {min: 22}});
+      expect(headerRow3.aggregations).toEqual({ agg1: {max: 'y'}, agg2: {min: 13}});
       
       expect( processingStates[0].currentGroupHeader ).toBe(headerRow1);
       processingStates[0].currentGroupHeader = 'x';
       expect( processingStates[1].currentGroupHeader ).toBe(grid.rows[3]);
       processingStates[1].currentGroupHeader = 'y';
       expect(processingStates).toEqual([
-        { 
-          fieldName: 'col1', 
+        {
+          fieldName: 'col1',
           col: grid.columns[1],
           initialised: true,
           currentValue: 'test',
@@ -476,9 +483,9 @@ describe('ui.grid.grouping uiGridGroupingService', function () {
             { fieldName: 'agg2', col: {}, type: uiGridGroupingConstants.aggregation.MIN, value: 98 }
           ]
         },
-        { 
+        {
           fieldName: 'col2',
-          col: grid.columns[2], 
+          col: grid.columns[2],
           initialised: true,
           currentValue: 'c_3',
           currentGroupHeader: 'y',
@@ -487,8 +494,8 @@ describe('ui.grid.grouping uiGridGroupingService', function () {
             { fieldName: 'agg2', col: {}, type: uiGridGroupingConstants.aggregation.MIN, value: null }
           ]
         },
-        { 
-          fieldName: 'col3', 
+        {
+          fieldName: 'col3',
           col: grid.columns[3],
           initialised: false,
           currentValue: null,
@@ -505,7 +512,8 @@ describe('ui.grid.grouping uiGridGroupingService', function () {
 
   describe('writeOutAggregations', function() {
     it('one state', function() {
-      var headerRow1 = new GridRow( {}, null, grid );
+      var headerRow1 = new GridRow( {$$getAggregatedValue: uiGridGroupingService.getGroupingAggregatedValue}, null, grid );
+      headerRow1.aggregations = {};
        
       var processingStates = [
         { 
@@ -514,7 +522,7 @@ describe('ui.grid.grouping uiGridGroupingService', function () {
           currentValue: 'test',
           currentGroupHeader: headerRow1,
           runningAggregations: [
-            { fieldName: 'agg1', col: {}, type: uiGridGroupingConstants.aggregation.MAX, value: '1234'},
+            { fieldName: 'agg1', col: {}, type: uiGridGroupingConstants.aggregation.MAX, value: 1234},
             { fieldName: 'agg2', col: {}, type: uiGridGroupingConstants.aggregation.MIN, value: 98 }
           ]
         }
@@ -522,7 +530,7 @@ describe('ui.grid.grouping uiGridGroupingService', function () {
       
       uiGridGroupingService.writeOutAggregations( grid, processingStates, 0 );
       
-      expect(headerRow1.entity).toEqual({ agg1: 'max: 1234', agg2: 'min: 98' });
+      expect(headerRow1.aggregations).toEqual({ agg1: {max: 1234}, agg2: {min: 98} });
       expect(processingStates).toEqual([
         {
           fieldName: 'col1', 
@@ -538,9 +546,13 @@ describe('ui.grid.grouping uiGridGroupingService', function () {
     });
     
     it('many states, start in the middle', function() {
-      var headerRow1 = new GridRow( {}, null, grid );
-      var headerRow2 = new GridRow( {}, null, grid );
-      var headerRow3 = new GridRow( {}, null, grid );
+      var headerRow1 = new GridRow( {$$getAggregatedValue: uiGridGroupingService.getGroupingAggregatedValue}, null, grid );
+      var headerRow2 = new GridRow( {$$getAggregatedValue: uiGridGroupingService.getGroupingAggregatedValue}, null, grid );
+      var headerRow3 = new GridRow( {$$getAggregatedValue: uiGridGroupingService.getGroupingAggregatedValue}, null, grid );
+
+      headerRow1.aggregations = {};
+      headerRow2.aggregations = {};
+      headerRow3.aggregations = {};
        
       var processingStates = [
         { 
@@ -577,9 +589,9 @@ describe('ui.grid.grouping uiGridGroupingService', function () {
       
       uiGridGroupingService.writeOutAggregations( grid, processingStates, 1 );
       
-      expect(headerRow1.entity).toEqual({});
-      expect(headerRow2.entity).toEqual({ agg1: 'max: x', agg2: 'min: 22' });
-      expect(headerRow3.entity).toEqual({ agg1: 'max: y', agg2: 'min: 13' });
+      expect(headerRow1.aggregations).toEqual({});
+      expect(headerRow2.aggregations).toEqual({ agg1: {max: 'x'}, agg2: {min: 22} });
+      expect(headerRow3.aggregations).toEqual({ agg1: {max: 'y'}, agg2: {min: 13} });
       
       expect(processingStates).toEqual([
         { 
@@ -666,61 +678,89 @@ describe('ui.grid.grouping uiGridGroupingService', function () {
     });
 
     it('some aggregations', function() {
-      var headerRow = new GridRow( {}, null, grid );
+      var headerRow = new GridRow( {$$getAggregatedValue: uiGridGroupingService.getGroupingAggregatedValue}, null, grid );
+      headerRow.aggregations = {};
+      headerRow.groupHeader = true;
        
-      var processingState = { 
-        fieldName: 'col1', 
+      var colAgg1 = {
+        grouping: {aggregation: 'max'},
+        groupingOriginalField: 'agg1'
+      };
+      var colAgg2 = {
+        grouping: {aggregation: 'min'},
+        groupingOriginalField: 'agg2'
+      };
+
+      var processingState = {
+        fieldName: 'col1',
         initialised: true,
         currentValue: 'test',
         currentGroupHeader: headerRow,
         runningAggregations: [
-          { fieldName: 'agg1', col: {}, type: uiGridGroupingConstants.aggregation.MAX, value: '1234'},
-          { fieldName: 'agg2', col: {}, type: uiGridGroupingConstants.aggregation.MIN, value: 98 }
+          { fieldName: 'agg1', col: colAgg1, type: uiGridGroupingConstants.aggregation.MAX, value: '1234'},
+          { fieldName: 'agg2', col: colAgg2, type: uiGridGroupingConstants.aggregation.MIN, value: 98 }
         ]
       };
       
       uiGridGroupingService.writeOutAggregation( grid, processingState );
       
-      expect(headerRow.entity).toEqual({ agg1: 'max: 1234', agg2: 'min: 98' });
+      expect(headerRow.aggregations).toEqual({ agg1: {max: '1234'}, agg2: {min: 98} });
+      expect(uiGridGroupingService.getGroupingAggregatedValue({row: headerRow, col: colAgg1})).toEqual('max: 1234');
+      expect(uiGridGroupingService.getGroupingAggregatedValue({row: headerRow, col: colAgg2})).toEqual('min: 98');
       expect(processingState).toEqual({
         fieldName: 'col1', 
         initialised: false,
         currentValue: null,
         currentGroupHeader: null,
         runningAggregations: [
-          { fieldName: 'agg1', col: {}, type: uiGridGroupingConstants.aggregation.MAX, value: null},
-          { fieldName: 'agg2', col: {}, type: uiGridGroupingConstants.aggregation.MIN, value: null }
+          { fieldName: 'agg1', col: colAgg1, type: uiGridGroupingConstants.aggregation.MAX, value: null},
+          { fieldName: 'agg2', col: colAgg2, type: uiGridGroupingConstants.aggregation.MIN, value: null}
         ]
-      });
+      }, 'processing state after writeOutAggregations');
     });
 
     it('groupingSuppressAggregationText', function() {
-      var headerRow = new GridRow( {}, null, grid );
+      var headerRow = new GridRow( {$$getAggregatedValue: uiGridGroupingService.getGroupingAggregatedValue}, null, grid );
+      headerRow.aggregations = {};
+      headerRow.groupHeader = true;
        
-      var processingState = { 
+      var colAgg1 = {
+        grouping: {aggregation: 'max'},
+        groupingOriginalField: 'agg1',
+        groupingSuppressAggregationText: true
+      };
+      var colAgg2 = {
+        grouping: {aggregation: 'min'},
+        groupingOriginalField: 'agg2',
+        groupingSuppressAggregationText: true
+      };
+
+      var processingState = {
         fieldName: 'col1', 
         initialised: true,
         currentValue: 'test',
         currentGroupHeader: headerRow,
         runningAggregations: [
-          { fieldName: 'agg1', col: { groupingSuppressAggregationText: true }, type: uiGridGroupingConstants.aggregation.MAX, value: '1234'},
-          { fieldName: 'agg2', col: { groupingSuppressAggregationText: true }, type: uiGridGroupingConstants.aggregation.MIN, value: 98 }
+          { fieldName: 'agg1', col: colAgg1, type: uiGridGroupingConstants.aggregation.MAX, value: '1234'},
+          { fieldName: 'agg2', col: colAgg2, type: uiGridGroupingConstants.aggregation.MIN, value: 98 }
         ]
       };
-      
+
       uiGridGroupingService.writeOutAggregation( grid, processingState );
-      
-      expect(headerRow.entity).toEqual({ agg1: '1234', agg2: 98 });
+
+      expect(headerRow.aggregations).toEqual({ agg1: {max: '1234'}, agg2: {min: 98}});
+      expect(uiGridGroupingService.getGroupingAggregatedValue({row: headerRow, col: colAgg1})).toEqual('1234');
+      expect(uiGridGroupingService.getGroupingAggregatedValue({row: headerRow, col: colAgg2})).toEqual(98);
       expect(processingState).toEqual({
         fieldName: 'col1', 
         initialised: false,
         currentValue: null,
         currentGroupHeader: null,
         runningAggregations: [
-          { fieldName: 'agg1', col: { groupingSuppressAggregationText: true }, type: uiGridGroupingConstants.aggregation.MAX, value: null},
-          { fieldName: 'agg2', col: { groupingSuppressAggregationText: true }, type: uiGridGroupingConstants.aggregation.MIN, value: null }
+          { fieldName: 'agg1', col: colAgg1, type: uiGridGroupingConstants.aggregation.MAX, value: null},
+          { fieldName: 'agg2', col: colAgg2, type: uiGridGroupingConstants.aggregation.MIN, value: null }
         ]
-      });
+      }, 'processing state after writeOutAggregations.');
     });
   });
   
@@ -810,8 +850,10 @@ describe('ui.grid.grouping uiGridGroupingService', function () {
   describe( 'setVisibility', function() {
     it( 'invisible', function() {
       var headerRow1 = new GridRow( {}, null, grid );
+      headerRow1.aggregations = {};
       var headerRow2 = new GridRow( {}, null, grid );
-      
+      headerRow2.aggregations = {};
+
       headerRow1.expandedState = { state: uiGridGroupingConstants.EXPANDED };
       headerRow2.expandedState = { state: uiGridGroupingConstants.COLLAPSED };
       
@@ -832,8 +874,10 @@ describe('ui.grid.grouping uiGridGroupingService', function () {
 
     it( 'visible', function() {
       var headerRow1 = new GridRow( {}, null, grid );
+      headerRow1.aggregations = {};
       var headerRow2 = new GridRow( {}, null, grid );
-      
+      headerRow2.aggregations = {};
+
       headerRow1.expandedState = { state: uiGridGroupingConstants.EXPANDED };
       headerRow2.expandedState = { state: uiGridGroupingConstants.EXPANDED };
       
@@ -867,7 +911,7 @@ describe('ui.grid.grouping uiGridGroupingService', function () {
       };
       
       var row = new GridRow( { col0: 'x', col1: 10, col2: '7', col3: '22' }, null, grid );
-      
+
       uiGridGroupingService.aggregate( grid, row, groupFieldState);
       
       expect( groupFieldState ).toEqual({

--- a/src/js/core/factories/Grid.js
+++ b/src/js/core/factories/Grid.js
@@ -1842,7 +1842,7 @@ angular.module('ui.grid')
         col.cellValueGetterCache = $parse(row.getEntityQualifiedColField(col));
       }
 
-      return col.cellValueGetterCache(row, {context: {row: row, col:col}});
+      return col.cellValueGetterCache(row, {row: row, col:col});
     }
   };
 

--- a/src/js/core/factories/Grid.js
+++ b/src/js/core/factories/Grid.js
@@ -1842,7 +1842,7 @@ angular.module('ui.grid')
         col.cellValueGetterCache = $parse(row.getEntityQualifiedColField(col));
       }
 
-      return col.cellValueGetterCache(row);
+      return col.cellValueGetterCache(row, {context: {row: row, col:col}});
     }
   };
 


### PR DESCRIPTION
functions expressions parsed by the getCellValue method will now receive an argument which is an object with both the current row and column This should not be breaking, since previously it was impossible to pass arguments to those functions.

The fix to grouping features is dependent on the new getCellValue method.