### PR TITLE
Fix null reference in grouping.js

### DIFF
--- a/src/features/grouping/js/grouping.js
+++ b/src/features/grouping/js/grouping.js
@@ -1413,7 +1413,7 @@
           
           var groupLevel = typeof(row.groupLevel) !== 'undefined' ? row.groupLevel : groupingProcessingState.length;
           for (var i = 0; i < groupLevel; i++){
-            if ( groupingProcessingState[i].currentGroupHeader.expandedState.state === uiGridGroupingConstants.COLLAPSED ){
+            if ( groupingProcessingState[i].currentGroupHeader && groupingProcessingState[i].currentGroupHeader.expandedState.state === uiGridGroupingConstants.COLLAPSED ){
              row.visible = false;
             }
           }


### PR DESCRIPTION
Happens sometimes (depends on sorting order) when having 2 or more colums with sorting and one of the sorted columns has also grouping

TypeError: Cannot read property 'expandedState' of null
    at Object.service.setVisibility (http://localhost/SomeProject/Scripts/angular/ui-grid-3.0.0.rapp.js:16607:63)
    at Grid.service.groupRows (http://localhost/SomeProject/Scripts/angular/ui-grid-3.0.0.rapp.js:16355:21)
    at startProcessor (http://localhost/SomeProject/Scripts/angular/ui-grid-3.0.0.rapp.js:4160:33)
    at handleProcessedRows (http://localhost/SomeProject/Scripts/angular/ui-grid-3.0.0.rapp.js:4176:20)
    at processQueue (http://localhost/SomeProject/Scripts/angular/angular-1.4.0-beta.6.js:14030:28)
    at http://localhost/SomeProject/Scripts/angular/angular-1.4.0-beta.6.js:14046:27
    at Scope.$eval (http://localhost/SomeProject/Scripts/angular/angular-1.4.0-beta.6.js:15253:28)
    at Scope.$digest (http://localhost/SomeProject/Scripts/angular/angular-1.4.0-beta.6.js:15068:31)
    at Scope.$apply (http://localhost/SomeProject/Scripts/angular/angular-1.4.0-beta.6.js:15358:24)
    at done (http://localhost/SomeProject/Scripts/angular/angular-1.4.0-beta.6.js:9834:47) undefined


![ui-grid-crash](https://cloud.githubusercontent.com/assets/1768681/7612524/b1981224-f98b-11e4-948f-8df7c0e29e42.png)
