### PR TITLE
Fix scroll up not propagating to parent

### DIFF
--- a/src/js/core/directives/ui-grid-render-container.js
+++ b/src/js/core/directives/ui-grid-render-container.js
@@ -74,10 +74,13 @@
                 var scrollYAmount = event.deltaY * -1 * event.deltaFactor;
 
                 scrollTop = containerCtrl.viewport[0].scrollTop;
+
+                var scrollCount = scrollTop + scrollYAmount;
                 // Get the scroll percentage
-                var scrollYPercentage = (scrollTop + scrollYAmount) / rowContainer.getVerticalScrollLength();
+                var scrollYPercentage = scrollCount / rowContainer.getVerticalScrollLength();
 
                 // Keep scrollPercentage within the range 0-1.
+                if (scrollCount < 0 && rowContainer.getVerticalScrollLength() < 0) { scrollYPercentage = 0; }
                 if (scrollYPercentage < 0) { scrollYPercentage = 0; }
                 else if (scrollYPercentage > 1) { scrollYPercentage = 1; }
 


### PR DESCRIPTION
Hello,

This pull request is to fix, what I consider a bug, the issue #3340

This 'bug' happen for a grid that displays less than its height (3 line, 3 * 30px, for a height of 300px for example). When this happening, the scroll up is not propagated to the parent.

I assumed that if the VerticalScrollLength AND the scrollTop + scrollYAmount is negative, then the scrollYPercentage is set to 0. 

It's working for a grid with the vertical scroll avalaible, or not.

