### PR TITLE
GridApi.suppressEvents should suppress all the handlers

### DIFF
--- a/src/js/core/factories/GridApi.js
+++ b/src/js/core/factories/GridApi.js
@@ -178,7 +178,7 @@
           //find all registered listeners
           var foundListeners = self.listeners.filter(function(listener) {
             return listeners.some(function(l) {
-              return listener.handler===l;
+              return listener.handler === l;
             });
           });
 

--- a/src/js/core/factories/GridApi.js
+++ b/src/js/core/factories/GridApi.js
@@ -176,10 +176,9 @@
           var listeners = angular.isArray(listenerFuncs) ? listenerFuncs : [listenerFuncs];
 
           //find all registered listeners
-          var foundListeners = [];
-          listeners.forEach(function (l) {
-            foundListeners = self.listeners.filter(function (lstnr) {
-              return l === lstnr.handler;
+          var foundListeners = self.listeners.filter(function(listener) {
+            return listeners.some(function(l) {
+              return listener.handler===l;
             });
           });
 


### PR DESCRIPTION
Fixed an issue where only the last found listener passed to GridApi.prototype.suppressEvents would actually be suppressed. (The foundListeners variable was being overwritten at each iteration.)