### PR TITLE
Fix for issue 3528. When exiting the grid the focusedCells list was n…

### DIFF
--- a/src/features/cellnav/js/cellnav.js
+++ b/src/features/cellnav/js/cellnav.js
@@ -677,7 +677,7 @@
                   // Figure out which new row+combo we're navigating to
                   var rowCol = uiGridCtrl.grid.renderContainers[containerId].cellNav.getNextRowCol(direction, lastRowCol.row, lastRowCol.col);
                   var focusableCols = uiGridCtrl.grid.renderContainers[containerId].cellNav.getFocusableCols();
-
+                  var rowColSelectIndex = uiGridCtrl.grid.api.cellNav.rowColSelectIndex(rowCol);
                   // Shift+tab on top-left cell should exit cellnav on render container
                   if (
                     // Navigating left
@@ -689,6 +689,7 @@
                     evt.keyCode === uiGridConstants.keymap.TAB &&
                     evt.shiftKey
                   ) {
+                    grid.cellNav.focusedCells.splice(rowColSelectIndex, 1);
                     uiGridCtrl.cellNav.clearFocus();
                     return true;
                   }
@@ -702,6 +703,7 @@
                     evt.keyCode === uiGridConstants.keymap.TAB &&
                     !evt.shiftKey
                   ) {
+                    grid.cellNav.focusedCells.splice(rowColSelectIndex, 1);
                     uiGridCtrl.cellNav.clearFocus();
                     return true;
                   }

--- a/src/features/cellnav/test/uiGridCellNavDirective.spec.js
+++ b/src/features/cellnav/test/uiGridCellNavDirective.spec.js
@@ -53,4 +53,22 @@ describe('ui.grid.cellNav directive', function () {
     $scope.grid.cellNav.broadcastCellNav({ row: $scope.grid.rows[1], col: $scope.grid.columns[0] }, true);
     expect($scope.gridApi.cellNav.getCurrentSelection().length).toEqual(2);
   });
+  
+  
+  it('handleKeyDown should clear the focused cells list when clearing focus', function () {
+	// first ensure that a cell is selected
+	$scope.grid.cellNav.broadcastCellNav({ row: $scope.grid.rows[0], col: $scope.grid.columns[0] }, true);
+    var rowColToTest = { row: $scope.grid.rows[0], col: $scope.grid.columns[0] };
+    var evt = jQuery.Event("keydown");
+    evt.keyCode = uiGridConstants.keymap.TAB;
+	$scope.grid.cellNav.lastRowCol = rowColToTest;
+	
+	// simulate tabbing out of grid
+    elm.controller('uiGrid').cellNav.handleKeyDown(evt);
+	expect($scope.grid.cellNav.focusedCells.length).toEqual(0);
+	
+	// simulate restoring focus
+	$scope.grid.cellNav.broadcastCellNav({ row: $scope.grid.rows[0], col: $scope.grid.columns[0] }, true);
+	expect($scope.grid.cellNav.focusedCells.length).toEqual(1);
+  });
 });


### PR DESCRIPTION
This is a fix for issue 3528. The idea is the focusedCells list wasn't getting cleared when navigating outside the grid and so the book keeping wasn't being done when focus was returned. There's a side effect here that I'm not sure about... With this fix tabbing out of the grid causes the focus highlight in the grid to disappear. I think it's probably valid but up to you! I included a unit test for the fix. 