### PR TITLE
fix(uiGridColumns): Fix auto-incrementing of column names

### DIFF
--- a/src/js/core/factories/Grid.js
+++ b/src/js/core/factories/Grid.js
@@ -983,51 +983,14 @@ angular.module('ui.grid')
     //field was required in 2.x.  now name is required
     if (colDef.name === undefined && colDef.field !== undefined) {
       // See if the column name already exists:
-      var foundName = self.getColumn(colDef.field);
-
-      // If a column with this name already  exists, we will add an incrementing number to the end of the new column name
-      if (foundName) {
-        // Search through the columns for names in the format: <name><1, 2 ... N>, i.e. 'Age1, Age2, Age3',
-        var nameRE = new RegExp('^' + colDef.field + '(\\d+)$', 'i');
-
-        var foundColumns = self.columns.filter(function (column) {
-          // Test against the displayName, as that's what'll have the incremented number
-          return nameRE.test(column.displayName);
-        })
-        // Sort the found columns by the end-number
-        .sort(function (a, b) {
-          if (a === b) {
-            return 0;
-          }
-          else {
-            var numA = a.displayName.match(nameRE)[1];
-            var numB = b.displayName.match(nameRE)[1];
-
-            return parseInt(numA, 10) > parseInt(numB, 10) ? 1 : -1;
-          }
-        });
-
-        // Not columns found, so start with number "2"
-        if (foundColumns.length === 0) {
-          colDef.name = colDef.field + '2';
-        }
-        else {
-          // Get the number from the final column
-          var lastNum = foundColumns[foundColumns.length-1].displayName.match(nameRE)[1];
-
-          // Make sure to parse to an int
-          lastNum = parseInt(lastNum, 10);
-
-          // Add 1 to the number from the last column and tack it on to the field to be the name for this new column
-          colDef.name = colDef.field + (lastNum + 1);
-        }
+      var newName = colDef.field,
+        counter = 2;
+      while (self.getColumn(newName)) {
+        newName = colDef.field + counter.toString();
+        counter++;
       }
-      // ... otherwise just use the field as the column name
-      else {
-        colDef.name = colDef.field;
-      }
+      colDef.name = newName;
     }
-
   };
 
   // Return a list of items that exist in the `n` array but not the `o` array. Uses optional property accessors passed as third & fourth parameters

--- a/test/unit/core/factories/GridColumn.spec.js
+++ b/test/unit/core/factories/GridColumn.spec.js
@@ -114,18 +114,18 @@ describe('GridColumn factory', function () {
 
         buildCols();
 
-        expect(grid.columns[0].displayName).toEqual('Age');
-        expect(grid.columns[1].displayName).toEqual('Name');
-        expect(grid.columns[2].displayName).toEqual('Name2');
-        expect(grid.columns[3].displayName).toEqual('Name3');
+        expect(grid.columns[0].name).toEqual('age');
+        expect(grid.columns[1].name).toEqual('name');
+        expect(grid.columns[2].name).toEqual('name2');
+        expect(grid.columns[3].name).toEqual('name3');
       });
 
-      it('should account for existing incremented names', function () {
+      it('should not change the displayNames if they are provided', function () {
         var cols = [
           { field: 'age' },
-          { field: 'name' },
-          { field: 'name', name: 'Name3' },
-          { field: 'name' }
+          { field: 'name', displayName:'First Name' },
+          { field: 'name', displayName:'First Name' },
+          { field: 'name', displayName:'First Name' }
         ];
 
         grid.options.columnDefs = cols;
@@ -133,9 +133,28 @@ describe('GridColumn factory', function () {
         buildCols();
 
         expect(grid.columns[0].displayName).toEqual('Age');
-        expect(grid.columns[1].displayName).toEqual('Name');
-        expect(grid.columns[2].displayName).toEqual('Name3');
-        expect(grid.columns[3].displayName).toEqual('Name4');
+        expect(grid.columns[1].displayName).toEqual('First Name');
+        expect(grid.columns[2].displayName).toEqual('First Name');
+        expect(grid.columns[3].displayName).toEqual('First Name');
+
+      });
+
+      it('should account for existing incremented names', function () {
+        var cols = [
+          { field: 'age' },
+          { field: 'name' },
+          { field: 'name', name: 'name3' },
+          { field: 'name' }
+        ];
+
+        grid.options.columnDefs = cols;
+
+        buildCols();
+
+        expect(grid.columns[0].name).toEqual('age');
+        expect(grid.columns[1].name).toEqual('name');
+        expect(grid.columns[2].name).toEqual('name3');
+        expect(grid.columns[3].name).toEqual('name2');
       });
     });
   });


### PR DESCRIPTION
When generating unique column names, do not consider the displayName.
Increment column name property only, using the field as the base.
Increment displayName property only if it is auto-generated,
displaying any provided displayName unchanged.

Fixes: #3453