### PR TITLE
fix(treeBase): Change calculation of number of levels in tree

### DIFF
--- a/misc/tutorial/320_complex_grouping.ngdoc
+++ b/misc/tutorial/320_complex_grouping.ngdoc
@@ -43,6 +43,7 @@ children of the selected rowHeader.
       $scope.gridOptions = {
         enableFiltering: true,
         enableGroupHeaderSelection: true,
+        treeRowHeaderAlwaysVisible: false,
         columnDefs: [
           { name: 'name', width: '30%' },
           { name: 'gender', grouping: { groupPriority: 1 }, sort: { priority: 1, direction: 'asc' }, editableCellTemplate: 'ui-grid/dropdownEditor', width: '20%',

--- a/src/features/tree-base/js/tree-base.js
+++ b/src/features/tree-base/js/tree-base.js
@@ -924,7 +924,7 @@
       updateRowHeaderWidth: function( grid ){
         var rowHeader = grid.getColumn(uiGridTreeBaseConstants.rowHeaderColName);
 
-        var newWidth = grid.options.treeRowHeaderBaseWidth + grid.options.treeIndent * grid.treeBase.numberLevels;
+        var newWidth = grid.options.treeRowHeaderBaseWidth + grid.options.treeIndent * Math.max(grid.treeBase.numberLevels - 1, 0);
         if ( rowHeader && newWidth !== rowHeader.width ){
           rowHeader.width = newWidth;
           grid.queueRefresh();
@@ -985,6 +985,7 @@
         var parents = [];
         var currentState;
         grid.treeBase.tree = [];
+        grid.treeBase.numberLevels = 0;
         var aggregations = service.getAggregations( grid );
 
         var createNode = function( row ){
@@ -1023,8 +1024,8 @@
           }
 
           // update the tree number of levels, so we can set header width if we need to
-          if ( grid.treeBase.numberLevels < row.treeLevel ){
-            grid.treeBase.numberLevels = row.treeLevel;
+          if ( grid.treeBase.numberLevels < row.treeLevel + 1){
+            grid.treeBase.numberLevels = row.treeLevel + 1;
           }
         };
 
@@ -1454,8 +1455,8 @@
    *  @description Stacks on top of ui.grid.uiGridViewport to set formatting on a tree header row
    */
   module.directive('uiGridViewport',
-  ['$compile', 'uiGridConstants', 'gridUtil', '$parse', 'uiGridGroupingService',
-    function ($compile, uiGridConstants, gridUtil, $parse, uiGridGroupingService) {
+  ['$compile', 'uiGridConstants', 'gridUtil', '$parse',
+    function ($compile, uiGridConstants, gridUtil, $parse) {
       return {
         priority: -200, // run after default  directive
         scope: false,

--- a/src/features/tree-base/test/tree-base.spec.js
+++ b/src/features/tree-base/test/tree-base.spec.js
@@ -172,7 +172,7 @@ describe('ui.grid.treeBase uiGridTreeBaseService', function () {
     it( 'tree the rows', function() {
       var treeRows = uiGridTreeBaseService.treeRows.call( grid, grid.rows.slice(0) );
       expect( treeRows.length ).toEqual( 2, 'only the level 0 rows are visible' );
-      expect( grid.treeBase.numberLevels).toEqual(2, 'two levels in the tree');
+      expect( grid.treeBase.numberLevels).toEqual(3, 'three levels in the tree');
     });
   });
 
@@ -244,7 +244,7 @@ describe('ui.grid.treeBase uiGridTreeBaseService', function () {
       expect( rows[0].treeNode ).toEqual( grid.treeBase.tree[0], 'treeNode is the first node in the tree' );
       delete rows[0].treeNode;
       expect( rows[0] ).toEqual( { uid: 1, treeLevel: 0, entity: { $$treeLevel: 0 }, visible: true }, 'treeLevel copied down' );
-      expect( grid.treeBase.numberLevels).toEqual(0, 'one level in the tree (is zero based like an array)');
+      expect( grid.treeBase.numberLevels).toEqual(1, 'one level in the tree');
       expect( grid.treeBase.tree.length).toEqual( 1, 'one node at root level of tree');
       expect( grid.treeBase.tree[0].row).toEqual( rows[0], 'node is for row 0');
       delete grid.treeBase.tree[0].row;
@@ -263,7 +263,7 @@ describe('ui.grid.treeBase uiGridTreeBaseService', function () {
       var tree = uiGridTreeBaseService.createTree( grid, rows );
 
       // overall settings
-      expect( grid.treeBase.numberLevels).toEqual(1, 'two levels in the tree (is zero based like an array)');
+      expect( grid.treeBase.numberLevels).toEqual(2, 'two levels in the tree');
 
       // rows
       expect( rows.length ).toEqual( 5, 'still only 5 rows' );
@@ -356,7 +356,7 @@ describe('ui.grid.treeBase uiGridTreeBaseService', function () {
       var tree = uiGridTreeBaseService.createTree( grid, rows );
 
       // overall settings
-      expect( grid.treeBase.numberLevels).toEqual(1, 'two levels in the tree (is zero based like an array)');
+      expect( grid.treeBase.numberLevels).toEqual(2, 'two levels in the tree');
 
       // rows
       expect( rows.length ).toEqual( 10, 'still only 10 rows' );


### PR DESCRIPTION
Change the treeBase.numberLevels variable to consider a single level as 1 instead of 0
Previously there was no way to use this variable to differentiate between a single tree level
and no grouping at all. This does not impact row.treeLevel, which is still zero-based.

Reset treeBase.numberLevels each time the tree is created.

Remove unneeded dependency for groupingService in treeBase.uiGridViewport directive

Add treeRowHeaderAlwaysVisible=false option to complex grouping tutorial (320).

Fixes: #3572