### PR TITLE
Fix column sort chrome triggers move event incorrectly #3333

### DIFF
--- a/src/features/move-columns/js/column-movable.js
+++ b/src/features/move-columns/js/column-movable.js
@@ -287,12 +287,14 @@
                 };
 
                 var moveFn = function( event ) {
+                  var changeValue = event.pageX - previousMouseX;
+                  if (changeValue === 0) { return; }
+
                   //Disable text selection in Chrome during column move
                   document.onselectstart = function() { return false; };
 
                   moveOccurred = true;
 
-                  var changeValue = event.pageX - previousMouseX;
                   if (!elmCloned) {
                     cloneElement();
                   }

--- a/src/js/core/directives/ui-grid-header-cell.js
+++ b/src/js/core/directives/ui-grid-header-cell.js
@@ -22,7 +22,7 @@
             var cellHeader = $compile($scope.col.headerCellTemplate)($scope);
             $elm.append(cellHeader);
           },
-          
+
           post: function ($scope, $elm, $attrs, controllers) {
             var uiGridCtrl = controllers[0];
             var renderContainerCtrl = controllers[1];
@@ -30,66 +30,68 @@
             $scope.grid = uiGridCtrl.grid;
 
             $scope.renderContainer = uiGridCtrl.grid.renderContainers[renderContainerCtrl.containerId];
-            
+
             var initColClass = $scope.col.getColClass(false);
             $elm.addClass(initColClass);
-    
+
             // Hide the menu by default
             $scope.menuShown = false;
-    
+
             // Put asc and desc sort directions in scope
             $scope.asc = uiGridConstants.ASC;
             $scope.desc = uiGridConstants.DESC;
-    
+
             // Store a reference to menu element
             var $colMenu = angular.element( $elm[0].querySelectorAll('.ui-grid-header-cell-menu') );
-    
+
             var $contentsElm = angular.element( $elm[0].querySelectorAll('.ui-grid-cell-contents') );
-    
+
 
             // apply any headerCellClass
             var classAdded;
-            
+            var previousMouseX;
+
             // filter watchers
             var filterDeregisters = [];
-            
-            
-            /* 
+
+
+            /*
              * Our basic approach here for event handlers is that we listen for a down event (mousedown or touchstart).
-             * Once we have a down event, we need to work out whether we have a click, a drag, or a 
-             * hold.  A click would sort the grid (if sortable).  A drag would be used by moveable, so 
+             * Once we have a down event, we need to work out whether we have a click, a drag, or a
+             * hold.  A click would sort the grid (if sortable).  A drag would be used by moveable, so
              * we ignore it.  A hold would open the menu.
-             * 
+             *
              * So, on down event, we put in place handlers for move and up events, and a timer.  If the
-             * timer expires before we see a move or up, then we have a long press and hence a column menu open.  
-             * If the up happens before the timer, then we have a click, and we sort if the column is sortable.  
+             * timer expires before we see a move or up, then we have a long press and hence a column menu open.
+             * If the up happens before the timer, then we have a click, and we sort if the column is sortable.
              * If a move happens before the timer, then we are doing column move, so we do nothing, the moveable feature
              * will handle it.
-             * 
+             *
              * To deal with touch enabled devices that also have mice, we only create our handlers when
-             * we get the down event, and we create the corresponding handlers - if we're touchstart then 
+             * we get the down event, and we create the corresponding handlers - if we're touchstart then
              * we get touchmove and touchend, if we're mousedown then we get mousemove and mouseup.
-             * 
+             *
              * We also suppress the click action whilst this is happening - otherwise after the mouseup there
              * will be a click event and that can cause the column menu to close
              *
              */
-            
+
             $scope.downFn = function( event ){
               event.stopPropagation();
 
               if (typeof(event.originalEvent) !== 'undefined' && event.originalEvent !== undefined) {
                 event = event.originalEvent;
               }
-    
+
               // Don't show the menu if it's not the left button
               if (event.button && event.button !== 0) {
                 return;
               }
-    
+              previousMouseX = event.pageX;
+
               $scope.mousedownStartTime = (new Date()).getTime();
               $scope.mousedownTimeout = $timeout(function() { }, mousedownTimeout);
-    
+
               $scope.mousedownTimeout.then(function () {
                 if ( $scope.colMenu ) {
                   uiGridCtrl.columnMenuScope.showMenu($scope.col, $elm, event);
@@ -97,7 +99,7 @@
               });
 
               uiGridCtrl.fireEvent(uiGridConstants.events.COLUMN_HEADER_CLICK, {event: event, columnName: $scope.col.colDef.name});
-              
+
               $scope.offAllEvents();
               if ( event.type === 'touchstart'){
                 $document.on('touchend', $scope.upFn);
@@ -107,7 +109,7 @@
                 $document.on('mousemove', $scope.moveFn);
               }
             };
-            
+
             $scope.upFn = function( event ){
               event.stopPropagation();
               $timeout.cancel($scope.mousedownTimeout);
@@ -116,7 +118,7 @@
 
               var mousedownEndTime = (new Date()).getTime();
               var mousedownTime = mousedownEndTime - $scope.mousedownStartTime;
-  
+
               if (mousedownTime > mousedownTimeout) {
                 // long click, handled above with mousedown
               }
@@ -127,19 +129,22 @@
                 }
               }
             };
-            
+
             $scope.moveFn = function( event ){
+              var changeX = previousMouseX - event.pageX;
+              if (changeX === 0 ) return;
+
               // we're a move, so do nothing and leave for column move (if enabled) to take over
               $timeout.cancel($scope.mousedownTimeout);
               $scope.offAllEvents();
               $scope.onDownEvents(event.type);
             };
-            
+
             $scope.clickFn = function ( event ){
               event.stopPropagation();
               $contentsElm.off('click', $scope.clickFn);
             };
-            
+
 
             $scope.offAllEvents = function(){
               $contentsElm.off('touchstart', $scope.downFn);
@@ -150,10 +155,10 @@
 
               $document.off('touchmove', $scope.moveFn);
               $document.off('mousemove', $scope.moveFn);
-              
+
               $contentsElm.off('click', $scope.clickFn);
             };
-            
+
             $scope.onDownEvents = function( type ){
               // If there is a previous event, then wait a while before
               // activating the other mode - i.e. if the last event was a touch event then
@@ -166,7 +171,7 @@
                   $contentsElm.on('click', $scope.clickFn);
                   $contentsElm.on('touchstart', $scope.downFn);
                   $timeout(function(){
-                    $contentsElm.on('mousedown', $scope.downFn);              
+                    $contentsElm.on('mousedown', $scope.downFn);
                   }, changeModeTimeout);
                   break;
                 case 'mousemove':
@@ -174,16 +179,16 @@
                   $contentsElm.on('click', $scope.clickFn);
                   $contentsElm.on('mousedown', $scope.downFn);
                   $timeout(function(){
-                    $contentsElm.on('touchstart', $scope.downFn);              
+                    $contentsElm.on('touchstart', $scope.downFn);
                   }, changeModeTimeout);
                   break;
                 default:
                   $contentsElm.on('click', $scope.clickFn);
                   $contentsElm.on('touchstart', $scope.downFn);
                   $contentsElm.on('mousedown', $scope.downFn);
-              }              
+              }
             };
-            
+
 
             var updateHeaderOptions = function( grid ){
               var contents = $elm;
@@ -191,7 +196,7 @@
                 contents.removeClass( classAdded );
                 classAdded = null;
               }
-  
+
               if (angular.isFunction($scope.col.headerCellClass)) {
                 classAdded = $scope.col.headerCellClass($scope.grid, $scope.row, $scope.col, $scope.rowRenderIndex, $scope.colRenderIndex);
               }
@@ -199,7 +204,7 @@
                 classAdded = $scope.col.headerCellClass;
               }
               contents.addClass(classAdded);
-              
+
               var rightMostContainer = $scope.grid.renderContainers['right'] ? $scope.grid.renderContainers['right'] : $scope.grid.renderContainers['body'];
               $scope.isLastCol = ( $scope.col === rightMostContainer.visibleColumnCache[ rightMostContainer.visibleColumnCache.length - 1 ] );
 
@@ -210,7 +215,7 @@
               else {
                 $scope.sortable = false;
               }
-      
+
               // Figure out whether this column is filterable or not
               var oldFilterable = $scope.filterable;
               if (uiGridCtrl.grid.options.enableFiltering && $scope.col.enableFiltering) {
@@ -234,7 +239,7 @@
                         uiGridCtrl.grid.api.core.notifyDataChange( uiGridConstants.dataChange.COLUMN );
                         uiGridCtrl.grid.queueGridRefresh();
                       }
-                    }));  
+                    }));
                   });
                   $scope.$on('$destroy', function() {
                     filterDeregisters.forEach( function(filterDeregister) {
@@ -245,18 +250,18 @@
                   filterDeregisters.forEach( function(filterDeregister) {
                     filterDeregister();
                   });
-                }                          
-                
+                }
+
               }
-              
+
               // figure out whether we support column menus
-              if ($scope.col.grid.options && $scope.col.grid.options.enableColumnMenus !== false && 
+              if ($scope.col.grid.options && $scope.col.grid.options.enableColumnMenus !== false &&
                       $scope.col.colDef && $scope.col.colDef.enableColumnMenu !== false){
                 $scope.colMenu = true;
               } else {
                 $scope.colMenu = false;
               }
-              
+
               /**
               * @ngdoc property
               * @name enableColumnMenu
@@ -275,16 +280,16 @@
               * column menus.  Defaults to true.
               *
               */
-  
+
               $scope.offAllEvents();
-              
+
               if ($scope.sortable || $scope.colMenu) {
                 $scope.onDownEvents();
-          
+
                 $scope.$on('$destroy', function () {
                   $scope.offAllEvents();
                 });
-              } 
+              }
             };
 
 /*
@@ -301,11 +306,11 @@
             });
 */
             updateHeaderOptions();
-            
+
             // Register a data change watch that would get triggered whenever someone edits a cell or modifies column defs
             var dataChangeDereg = $scope.grid.registerDataChangeCallback( updateHeaderOptions, [uiGridConstants.dataChange.COLUMN]);
 
-            $scope.$on( '$destroy', dataChangeDereg );            
+            $scope.$on( '$destroy', dataChangeDereg );
 
             $scope.handleClick = function(event) {
               // If the shift key is being held down, add this column to the sort
@@ -313,7 +318,7 @@
               if (event.shiftKey) {
                 add = true;
               }
-    
+
               // Sort this column then rebuild the grid's rows
               uiGridCtrl.grid.sortColumn($scope.col, add)
                 .then(function () {
@@ -321,11 +326,11 @@
                   uiGridCtrl.grid.refresh();
                 });
             };
-    
+
 
             $scope.toggleMenu = function(event) {
               event.stopPropagation();
-    
+
               // If the menu is already showing...
               if (uiGridCtrl.columnMenuScope.menuShown) {
                 // ... and we're the column the menu is on...

--- a/src/js/core/directives/ui-grid-header-cell.js
+++ b/src/js/core/directives/ui-grid-header-cell.js
@@ -132,7 +132,7 @@
 
             $scope.moveFn = function( event ){
               var changeX = previousMouseX - event.pageX;
-              if (changeX === 0 ) return;
+              if (changeX === 0 ) { return; }
 
               // we're a move, so do nothing and leave for column move (if enabled) to take over
               $timeout.cancel($scope.mousedownTimeout);


### PR DESCRIPTION
Fix for issue where sometimes in chrome, a move event gets called immediately proceeding a down event, regardless of whether or not there was any movement.

Issue #3333 

(I apologize for the whitespace spam, changes in ui-grid-header-cell.js are lines 52, 90, and 134)