### PR TITLE
Added dynamic height for subgrids

### DIFF
--- a/src/features/expandable/js/expandable.js
+++ b/src/features/expandable/js/expandable.js
@@ -23,7 +23,7 @@
   module.service('uiGridExpandableService', ['gridUtil', '$compile', function (gridUtil, $compile) {
     var service = {
       initializeGrid: function (grid) {
-        
+
         grid.expandable = {};
         grid.expandable.expandedAll = false;
 
@@ -32,16 +32,16 @@
          *  @name enableExpandable
          *  @propertyOf  ui.grid.expandable.api:GridOptions
          *  @description Whether or not to use expandable feature, allows you to turn off expandable on specific grids
-         *  within your application, or in specific modes on _this_ grid. Defaults to true.  
+         *  within your application, or in specific modes on _this_ grid. Defaults to true.
          *  @example
          *  <pre>
          *    $scope.gridOptions = {
          *      enableExpandable: false
          *    }
-         *  </pre>  
+         *  </pre>
          */
         grid.options.enableExpandable = grid.options.enableExpandable !== false;
-        
+
         /**
          *  @ngdoc object
          *  @name expandableRowHeight
@@ -53,13 +53,13 @@
          *    $scope.gridOptions = {
          *      expandableRowHeight: 150
          *    }
-         *  </pre>  
+         *  </pre>
          */
         grid.options.expandableRowHeight = grid.options.expandableRowHeight || 150;
 
         /**
          *  @ngdoc object
-         *  @name 
+         *  @name
          *  @propertyOf  ui.grid.expandable.api:GridOptions
          *  @description Width in pixels of the expandable column. Defaults to 40
          *  @example
@@ -67,7 +67,7 @@
          *    $scope.gridOptions = {
          *      expandableRowHeaderWidth: 40
          *    }
-         *  </pre>  
+         *  </pre>
          */
         grid.options.expandableRowHeaderWidth = grid.options.expandableRowHeaderWidth || 40;
 
@@ -81,7 +81,7 @@
          *    $scope.gridOptions = {
          *      expandableRowTemplate: 'expandableRowTemplate.html'
          *    }
-         *  </pre>  
+         *  </pre>
          */
         if ( grid.options.enableExpandable && !grid.options.expandableRowTemplate ){
           gridUtil.logError( 'You have not set the expandableRowTemplate, disabling expandable module' );
@@ -98,7 +98,7 @@
          *  @ngdoc object
          *  @name ui.grid.expandable.api:GridOptions
          *
-         *  @description Options for configuring the expandable feature, these are available to be  
+         *  @description Options for configuring the expandable feature, these are available to be
          *  set using the ui-grid {@link ui.grid.class:GridOptions gridOptions}
          */
         var publicApi = {
@@ -118,7 +118,7 @@
               }
             }
           },
-          
+
           methods: {
             expandable: {
               /**
@@ -130,7 +130,7 @@
                *      gridApi.expandable.toggleRowExpansion(rowEntity);
                * </pre>
                * @param {object} rowEntity the data entity for the row you want to expand
-               */              
+               */
               toggleRowExpansion: function (rowEntity) {
                 var row = grid.getRow(rowEntity);
                 if (row !== null) {
@@ -146,7 +146,7 @@
                * <pre>
                *      gridApi.expandable.expandAllRows();
                * </pre>
-               */              
+               */
               expandAllRows: function() {
                 service.expandAllRows(grid);
               },
@@ -159,7 +159,7 @@
                * <pre>
                *      gridApi.expandable.collapseAllRows();
                * </pre>
-               */              
+               */
               collapseAllRows: function() {
                 service.collapseAllRows(grid);
               },
@@ -172,7 +172,7 @@
                * <pre>
                *      gridApi.expandable.toggleAllRows();
                * </pre>
-               */              
+               */
               toggleAllRows: function() {
                 service.toggleAllRows(grid);
               }
@@ -182,19 +182,23 @@
         grid.api.registerEventsFromObject(publicApi.events);
         grid.api.registerMethodsFromObject(publicApi.methods);
       },
-      
+
       toggleRowExpansion: function (grid, row) {
         row.isExpanded = !row.isExpanded;
-        if (row.isExpanded) {
-          row.height = row.grid.options.rowHeight + grid.options.expandableRowHeight;
-        }
-        else {
-          row.height = row.grid.options.rowHeight;
-          grid.expandable.expandedAll = false;
-        }
+        gridUtil.getTemplate(grid.options.expandableRowTemplate).then(function(template) {
+          row.subGridOptions = eval(angular.element(template)[0].getAttribute('ui-grid'));
+          row.subGridHeight = (row.subGridOptions.data.length * row.grid.options.rowHeight) + row.grid.options.rowHeight + 2.5;
+          if (row.isExpanded) {
+            row.height = row.subGridHeight ? row.subGridHeight : (row.grid.options.rowHeight + grid.options.expandableRowHeight);
+          }
+          else {
+            row.height = row.grid.options.rowHeight;
+            grid.expandable.expandedAll = false;
+          }
+        });
         grid.api.expandable.raise.rowExpandedStateChanged(row);
       },
-      
+
       expandAllRows: function(grid, $scope) {
         grid.renderContainers.body.visibleRowCache.forEach( function(row) {
           if (!row.isExpanded) {
@@ -204,7 +208,7 @@
         grid.expandable.expandedAll = true;
         grid.queueGridRefresh();
       },
-      
+
       collapseAllRows: function(grid) {
         grid.renderContainers.body.visibleRowCache.forEach( function(row) {
           if (row.isExpanded) {
@@ -238,7 +242,7 @@
    *    $scope.gridOptions = {
    *      enableExpandableRowHeader: false
    *    }
-   *  </pre>  
+   *  </pre>
    */
   module.directive('uiGridExpandable', ['uiGridExpandableService', '$templateCache',
     function (uiGridExpandableService, $templateCache) {
@@ -252,10 +256,10 @@
             pre: function ($scope, $elm, $attrs, uiGridCtrl) {
               if ( uiGridCtrl.grid.options.enableExpandableRowHeader !== false ) {
                 var expandableRowHeaderColDef = {
-                  name: 'expandableButtons', 
-                  displayName: '', 
-                  exporterSuppressExport: true, 
-                  enableColumnResizing: false, 
+                  name: 'expandableButtons',
+                  displayName: '',
+                  exporterSuppressExport: true,
+                  enableColumnResizing: false,
                   enableColumnMenu: false,
                   width: uiGridCtrl.grid.options.expandableRowHeaderWidth || 40
                 };
@@ -392,10 +396,14 @@
                   return ret;
                 };
 
+                $scope.expandableRow.getHeight = function() {
+                  return $scope.row.height;
+                }
+
  /*
   * Commented out @PaulL1.  This has no purpose that I can see, and causes #2964.  If this code needs to be reinstated for some
   * reason it needs to use drawnWidth, not width, and needs to check column visibility.  It should really use render container
-  * visible column cache also instead of checking column.renderContainer. 
+  * visible column cache also instead of checking column.renderContainer.
                   function updateRowContainerWidth() {
                       var grid = $scope.grid;
                       var colWidth = 0;

--- a/src/features/expandable/templates/expandableRow.html
+++ b/src/features/expandable/templates/expandableRow.html
@@ -1,4 +1,4 @@
 <div ui-grid-expandable-row ng-if="expandableRow.shouldRenderExpand()" class="expandableRow"
      style="float:left; margin-top: 1px; margin-bottom: 1px"
      ng-style="{width: (grid.renderContainers.body.getCanvasWidth()) + 'px'
-     , height: grid.options.expandableRowHeight + 'px'}"></div>
+     , height: expandableRow.getHeight() + 'px'}"></div>

--- a/src/features/expandable/templates/expandableScrollFiller.html
+++ b/src/features/expandable/templates/expandableScrollFiller.html
@@ -1,7 +1,7 @@
 <div ng-if="expandableRow.shouldRenderFiller()"
      ng-class="{scrollFiller:true, scrollFillerClass:(colContainer.name === 'body')}"
      ng-style="{ width: (grid.getViewportWidth()) + 'px',
-              height: grid.options.expandableRowHeight + 2 + 'px', 'margin-left': grid.options.rowHeader.rowHeaderWidth + 'px' }"
+              height: expandableRow.getHeight() + 2 + 'px', 'margin-left': grid.options.rowHeader.rowHeaderWidth + 'px' }"
      >
     <i class="ui-grid-icon-spin5 ui-grid-animate-spin" ng-style=
             "{ 'margin-top': ( grid.options.expandableRowHeight/2 - 5) + 'px',


### PR DESCRIPTION
This PR adds a dynamic height for subgrids instead of setting one fixed height for all subgrids (which easily becomes very frustrating to use when there are large discrepancies in subgrids, resulting in large amounts of whitespace). Addresses #2549 along with many other issues I've noticed when first looking for a solution.

The change has been used for about ~2 months on my own application and worked perfectly for my use cases. Hasn't been tested extensively otherwise.