### PR TITLE
Enh(grunt): add "feature" option to test only one feature

### DIFF
--- a/lib/grunt/utils.js
+++ b/lib/grunt/utils.js
@@ -17,6 +17,14 @@ var util = module.exports = {
     unit: ['src/js/core/bootstrap.js', 'src/js/**/*.js', 'test/unit/**/*.spec.js', 'src/features/*/js/**/*.js', 'src/features/*/test/**/*.spec.js', '.tmp/template.js'],
     core_unit: ['src/js/core/bootstrap.js', 'src/js/**/*.js', 'test/unit/**/*.spec.js', 'src/features/*/js/**/*.js', '.tmp/template.js'],
   },
+  testFilesFeature: function(featureName){
+    var featurePattern = 'src/features/' + featureName +'/test/**/*.spec.js';
+
+    return {
+      unit: ['src/js/core/bootstrap.js', 'src/js/**/*.js', 'test/unit/**/*.spec.js', 'src/features/*/js/**/*.js', featurePattern, '.tmp/template.js'],
+      core_unit: util.testDependencies.unit.core_unit
+    };
+  },
 
   // Return a list of angular files for a specific version
   angularFiles: function (version) {
@@ -211,12 +219,20 @@ var util = module.exports = {
               .concat(util.testFiles.core_unit))
           }
         });
+      } else if ( grunt.option('feature') ){
+        grunt.config('karma.' + karmaConfigName, {
+          options: {
+            files: util.testDependencies.unit
+              .concat(util.angularFiles(version)
+              .concat(util.testFilesFeature(grunt.option('feature')).unit))
+          }
+        });
       } else {
         grunt.config('karma.' + karmaConfigName, {
           options: {
             files: util.testDependencies.unit
               .concat(util.angularFiles(version)
-              .concat(util.testFiles.unit))
+                .concat(util.testFiles.unit))
           }
         });
       }


### PR DESCRIPTION
Speeds up tests when working on a specific feature, by skipping unit tests for
all other features.
Use it like grunt test --feature=tree-base