### PR TITLE
fix #3560 pinning column got malfunctioned when chrome not zoom to 100%

### DIFF
--- a/src/services/DomUtilityService.js
+++ b/src/services/DomUtilityService.js
@@ -140,7 +140,7 @@
         if (grid.styleText) {
             var regex = regexCache[col.index];
             if (!regex) {
-                regex = regexCache[col.index] = new RegExp(".col" + col.index + " { width: [0-9]+px; left: [0-9]+px");
+                regex = regexCache[col.index] = new RegExp(".col" + col.index + " { width: [+-]?\\d+(\\.\\d+)?px; left: [+-]?\\d+(\\.\\d+)?px");
             }
             var css = grid.styleText.replace(regex, ".col" + col.index + " { width: " + col.width + "px; left: " + colLeft + "px");
             domUtilityService.setStyleText(grid, css);


### PR DESCRIPTION
Calculation of pinned column's new left while scrolling will occur floating point under Chrome. Let domUtilityService.setColLeft also be able to support floating point value.