### PR TITLE
Hide filter cancel button if filter input is an empty string

### DIFF
--- a/src/templates/ui-grid/ui-grid-filter.html
+++ b/src/templates/ui-grid/ui-grid-filter.html
@@ -13,7 +13,7 @@
     </select>
 
     <div class="ui-grid-filter-button-select" ng-click="colFilter.term = null" ng-if="!colFilter.disableCancelFilterButton">
-      <i class="ui-grid-icon-cancel" ng-show="colFilter.term !== undefined && colFilter.term != null">&nbsp;</i>
+      <i class="ui-grid-icon-cancel" ng-show="colFilter.term !== undefined && colFilter.term != null && colFilter.term !== ''">&nbsp;</i>
     </div>
   </div>
 </div>


### PR DESCRIPTION
The filter cancellation button is still visible if I type some characters into a filter textbox and subsequently delete all the characters.  The "ng-show" on the filter cancellation button currently does not test for empty strings.