### PR TITLE
Fixed scrolling when verticalScrollHeight is 0

### DIFF
--- a/src/js/core/directives/ui-grid-render-container.js
+++ b/src/js/core/directives/ui-grid-render-container.js
@@ -75,7 +75,10 @@
 
                 scrollTop = containerCtrl.viewport[0].scrollTop;
                 // Get the scroll percentage
-                var scrollYPercentage = (scrollTop + scrollYAmount) / rowContainer.getVerticalScrollLength();
+                var verticalScrollLength = rowContainer.getVerticalScrollLength();
+                var scrollYPercentage;
+                if (verticalScrollLength === 0) { scrollYPercentage = 0; }
+                else { scrollYPercentage = (scrollTop + scrollYAmount) / verticalScrollLength; }
 
                 // Keep scrollPercentage within the range 0-1.
                 if (scrollYPercentage < 0) { scrollYPercentage = 0; }


### PR DESCRIPTION
Open the basic example:
http://ui-grid.info/docs/#/tutorial/101_intro
Hover above the grid and try to scroll up - it doesn't scroll the page.
Scrolling down, however, works.

This fixes it