### PR TITLE
Changed from offsetParent to parentElement. Use of offsetParent is a …

### DIFF
--- a/src/js/core/services/ui-grid-util.js
+++ b/src/js/core/services/ui-grid-util.js
@@ -151,7 +151,7 @@ function getWidthOrHeight( elem, name, extra ) {
 
 function getLineHeight(elm) {
   elm = angular.element(elm)[0];
-  var parent = elm.offsetParent;
+  var parent = elm.parentElement;
 
   if (!parent) {
     parent = document.getElementsByTagName('body')[0];


### PR DESCRIPTION
…major performance degradation (in IE, any use of offsetParent, offsetWidth or offsetHeight should be used with extreme caution) , it causes document reflow/layout in the browser.

I can't see why this have to be offsetParent, it looks like it is the nearest parent of the element that is the target. If changed to parentElement this would have a positive effect on the initial rendering performance. If all calls to offsetWidth, offsetHeight and offsetParent are eliminated from the initial rendering, the initial rendering time drops by almost 40% in our application.