### PR TITLE
Add saveSelection to save state doc

### DIFF
--- a/misc/tutorial/208_save_state.ngdoc
+++ b/misc/tutorial/208_save_state.ngdoc
@@ -34,6 +34,7 @@ default:
 - saveGrouping
 - saveGroupingExpandedStates
 - saveTreeView
+- saveSelection
 
 @example
 In this example we provide a button to save the grid state.  You can then modify the grid layout


### PR DESCRIPTION
The saveSelection option was missing in the list