### PR TITLE
Fix(moveColumn): ignore move events without movement

### DIFF
--- a/src/features/move-columns/js/column-movable.js
+++ b/src/features/move-columns/js/column-movable.js
@@ -287,12 +287,13 @@
                 };
 
                 var moveFn = function( event ) {
+                  var changeValue = event.pageX - previousMouseX;
+                  if ( changeValue === 0 ){ return; }
                   //Disable text selection in Chrome during column move
                   document.onselectstart = function() { return false; };
 
                   moveOccurred = true;
 
-                  var changeValue = event.pageX - previousMouseX;
                   if (!elmCloned) {
                     cloneElement();
                   }

--- a/src/js/core/directives/ui-grid-header-cell.js
+++ b/src/js/core/directives/ui-grid-header-cell.js
@@ -49,7 +49,8 @@
 
             // apply any headerCellClass
             var classAdded;
-            
+            var previousMouseX;
+
             // filter watchers
             var filterDeregisters = [];
             
@@ -86,7 +87,8 @@
               if (event.button && event.button !== 0) {
                 return;
               }
-    
+              previousMouseX = event.pageX;
+
               $scope.mousedownStartTime = (new Date()).getTime();
               $scope.mousedownTimeout = $timeout(function() { }, mousedownTimeout);
     
@@ -129,6 +131,10 @@
             };
             
             $scope.moveFn = function( event ){
+              // Chrome is known to fire some bogus move events.
+              var changeValue = event.pageX - previousMouseX;
+              if ( changeValue === 0 ){ return; }
+
               // we're a move, so do nothing and leave for column move (if enabled) to take over
               $timeout.cancel($scope.mousedownTimeout);
               $scope.offAllEvents();


### PR DESCRIPTION
This is primarily to deal with a bug in chrome where move events are
sometimes triggered even when the cursor does not move.

Fix #3333