### PR TITLE
Add expectHeaderColumns() to gridTestUtils.

### DIFF
--- a/test/e2e/gridTestUtils.spec.js
+++ b/test/e2e/gridTestUtils.spec.js
@@ -176,6 +176,35 @@ module.exports = {
   },
 
   /**
+   * @ngdoc method
+   * @methodOf ui.grid.e2eTestLibrary.api:gridTest
+   * @name expectHeaderColumns
+   * @description Checks that a grid has the given column headers.
+   * @param {string} gridId The ID of the grid that you want to inspect.
+   * @param {array} expectedColumns The column headers you expect.
+   *
+   * @example
+   * <pre>
+   *   gridTestUtils.expectHeaderColumns('myGrid', ['ID', 'Name', 'Email']);
+   * </pre>
+   */
+  expectHeaderColumns: function(gridId, expectedColumns) {
+    var headerColumns = this.getGrid(gridId)
+      .element(by.css('.ui-grid-render-container-body'))
+      .element( by.css('.ui-grid-header'))
+      .all(by.repeater('col in colContainer.renderedColumns track by col.uid'));
+
+    expect(headerColumns.count()).toBe(expectedColumns.length);
+
+    headerColumns.getText().then(function(columnTexts) {
+      columnTexts = columnTexts.map(function trimText(text) {
+        return text.replace(/^\s+/, '').replace(/\s+$/, '');
+      });
+      expect(columnTexts).toEqual(expectedColumns);
+    });
+  },
+
+  /**
   * @ngdoc method
   * @methodOf ui.grid.e2eTestLibrary.api:gridTest
   * @name expectHeaderLeftColumnCount


### PR DESCRIPTION
This reduces a lot of duplicate code.

Example before this:

    it('should have 6 columns', function() {
        gridTestUtils.expectHeaderColumnCount('users-table', 6);
        gridTestUtils.expectHeaderCellValueMatch('users-table', 0, 'ID');
        gridTestUtils.expectHeaderCellValueMatch('users-table', 1, 'Name');
        gridTestUtils.expectHeaderCellValueMatch('users-table', 2, 'Email');
        gridTestUtils.expectHeaderCellValueMatch('users-table', 3, 'Group');
        gridTestUtils.expectHeaderCellValueMatch('users-table', 4, 'Last Login');
        gridTestUtils.expectHeaderCellValueMatch('users-table', 5, 'Action');
    });

Example after this:

    it('should have 6 columns', function() {
        gridTestUtils.expectHeaderColumns('users-table', [
            'ID',
            'Name',
            'Email',
            'Group',
            'Last Login',
            'Action',
        ]);
    });
