### PR TITLE
Ensure cellFilters in gridClassFactory are passed without modifications

### DIFF
--- a/src/js/core/services/gridClassFactory.js
+++ b/src/js/core/services/gridClassFactory.js
@@ -120,7 +120,9 @@
                   }
 
                   if ( filterType ){
-                    col[templateType] = template.replace(uiGridConstants.CUSTOM_FILTERS, col[filterType] ? "|" + col[filterType] : "");
+                    col[templateType] = template.replace(uiGridConstants.CUSTOM_FILTERS, function() {
+                      return col[filterType] ? "|" + col[filterType] : "";
+                    });
                   } else {
                     col[templateType] = template;
                   }

--- a/test/unit/core/services/GridClassFactory.spec.js
+++ b/test/unit/core/services/GridClassFactory.spec.js
@@ -115,7 +115,29 @@ describe('gridClassFactory', function() {
       expect(testSetup.col.cellTemplate).toEqual('<div>a sample cell template with custom_filters</div>');      
       expect(testSetup.col.footerCellTemplate).toEqual('<div>a sample footer template with custom_filters</div>');
     });
-    
+
+    it('column builder passes double dollars as parameters to the filters correctly', function() {
+      testSetup.$templateCache.put('ui-grid/uiGridHeaderCell', '<div>a sample header template with CUSTOM_FILTERS</div>');
+      testSetup.$templateCache.put('ui-grid/uiGridCell', '<div>a sample cell template with CUSTOM_FILTERS</div>');
+      testSetup.$templateCache.put('ui-grid/uiGridFooterCell', '<div>a sample footer template with CUSTOM_FILTERS</div>');
+
+      testSetup.col.cellFilter = 'customCellFilter:row.entity.$$internalValue';
+      testSetup.col.headerCellFilter = 'customHeaderCellFilter:row.entity.$$internalValue';
+      testSetup.col.footerCellFilter = 'customFooterCellFilter:row.entity.$$internalValue';
+
+      gridClassFactory.defaultColumnBuilder( testSetup.colDef, testSetup.col, testSetup.gridOptions );
+
+      expect(testSetup.col.providedHeaderCellTemplate).toEqual('ui-grid/uiGridHeaderCell');
+      expect(testSetup.col.providedCellTemplate).toEqual('ui-grid/uiGridCell');
+      expect(testSetup.col.providedFooterCellTemplate).toEqual('ui-grid/uiGridFooterCell');
+
+      testSetup.$rootScope.$digest();
+
+      expect(testSetup.col.headerCellTemplate).toEqual('<div>a sample header template with |customHeaderCellFilter:row.entity.$$internalValue</div>');
+      expect(testSetup.col.cellTemplate).toEqual('<div>a sample cell template with |customCellFilter:row.entity.$$internalValue</div>');
+      expect(testSetup.col.footerCellTemplate).toEqual('<div>a sample footer template with |customFooterCellFilter:row.entity.$$internalValue</div>');
+    });
+
   });
 
 });


### PR DESCRIPTION
We have stored some precalculated data in UI-grid's row with the ```$$``` prefix which we access in the column with Angular's filter. Regardless of if that is the best solution or not, I found the following unexpected behaviour:

A cell filter
```
testSetup.col.cellFilter = 'customCellFilter:row.entity.$$internalValue';
```
causes cell's filter template to be replaced with
```
customHeaderCellFilter:row.entity.$internalValue
```
. It is missing one dollar sign.

This is caused by [String.prototype.replace()'s] (https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/String/replace) special replacement patterns. We can prevent this by passing the second parameter with an anonymous function in ```gridClassFactory.js```.
