### PR TITLE
Fixes one bind tests failing with Angular 1.2

### DIFF
--- a/src/js/core/directives/ui-grid-one-bind.js
+++ b/src/js/core/directives/ui-grid-one-bind.js
@@ -302,7 +302,8 @@
                 //Removes the watcher on itself after the bind
                 rmWatcher();
               }
-            }); //End rm watchers
+            // True ensures that equality is determined using angular.equals instead of ===
+            }, true); //End rm watchers
           } //End compile function
         }; //End directive return
       } // End directive function


### PR DESCRIPTION
The $scope.$watch used `===` for equality comparisons by default and 1.3
uses `angular.equals`. The desired behaior is acheived using
`angular.equals`.