### PR TITLE
Updating column width when columnDefs changes

### DIFF
--- a/src/features/resize-columns/js/ui-grid-column-resizer.js
+++ b/src/features/resize-columns/js/ui-grid-column-resizer.js
@@ -318,17 +318,13 @@
           $elm.addClass('right');
         }
 
-        // Build the columns then refresh the grid canvas
+        // Refresh the grid canvas
         //   takes an argument representing the diff along the X-axis that the resize had
-        function buildColumnsAndRefresh(xDiff) {
-          // Build the columns
-          uiGridCtrl.grid.buildColumns()
-            .then(function() {
-              // Then refresh the grid canvas, rebuilding the styles so that the scrollbar updates its size
-              uiGridCtrl.grid.refreshCanvas(true).then( function() {
-                uiGridCtrl.grid.queueGridRefresh();
-              });
-            });
+        function refreshCanvas(xDiff) {
+          // Then refresh the grid canvas, rebuilding the styles so that the scrollbar updates its size
+          uiGridCtrl.grid.refreshCanvas(true).then( function() {
+            uiGridCtrl.grid.queueGridRefresh();
+          });
         }
 
         // Check that the requested width isn't wider than the maxWidth, or narrower than the minWidth
@@ -424,7 +420,7 @@
           // check we're not outside the allowable bounds for this column
           col.width = constrainWidth(col, newWidth);
 
-          buildColumnsAndRefresh(xDiff);
+          refreshCanvas(xDiff);
 
           uiGridResizeColumnsService.fireColumnSizeChanged(uiGridCtrl.grid, col.colDef, xDiff);
 
@@ -536,7 +532,7 @@
           // check we're not outside the allowable bounds for this column
           col.width = constrainWidth(col, maxWidth);
           
-          buildColumnsAndRefresh(xDiff);
+          refreshCanvas(xDiff);
           
           uiGridResizeColumnsService.fireColumnSizeChanged(uiGridCtrl.grid, col.colDef, xDiff);        };
         $elm.on('dblclick', dblClickFn);

--- a/src/features/resize-columns/test/resizeColumns.spec.js
+++ b/src/features/resize-columns/test/resizeColumns.spec.js
@@ -211,7 +211,6 @@ describe('ui.grid.resizeColumns', function () {
         it('should cause the column to resize by the amount change in the X axis', function () {
           var firstColumnUid = gridScope.grid.columns[0].uid;
           var newWidth = $(grid).find('.' + uiGridConstants.COL_CLASS_PREFIX + firstColumnUid).first().width();
-
           expect(newWidth - initialWidth).toEqual(xDiff);
         });
 

--- a/src/js/core/factories/GridColumn.js
+++ b/src/js/core/factories/GridColumn.js
@@ -425,44 +425,38 @@ angular.module('ui.grid')
 
     self.displayName = (colDef.displayName === undefined) ? gridUtil.readableColumnName(colDef.name) : colDef.displayName;
     
-    var parseErrorMsg = "Cannot parse column width '" + colDef.width + "' for column named '" + colDef.name + "'";
+    var colDefWidth = colDef.width;
+    var parseErrorMsg = "Cannot parse column width '" + colDefWidth + "' for column named '" + colDef.name + "'";
 
-    // If width is not defined, set it to a single star
-    if (gridUtil.isNullOrUndefined(self.width) || !angular.isNumber(self.width)) {
-      if (gridUtil.isNullOrUndefined(colDef.width)) {
-        self.width = '*';
+    if (!angular.isString(colDefWidth) && !angular.isNumber(colDefWidth)) {
+      self.width = '*';
+    } else if (angular.isString(colDefWidth)) {
+      // See if it ends with a percent
+      if (gridUtil.endsWith(colDefWidth, '%')) {
+        // If so we should be able to parse the non-percent-sign part to a number
+        var percentStr = colDefWidth.replace(/%/g, '');
+        var percent = parseInt(percentStr, 10);
+        if (isNaN(percent)) {
+          throw new Error(parseErrorMsg);
+        }
+        self.width = colDefWidth;
       }
+      // And see if it's a number string
+      else if (colDefWidth.match(/^(\d+)$/)) {
+        self.width = parseInt(colDefWidth.match(/^(\d+)$/)[1], 10);
+      }
+      // Otherwise it should be a string of asterisks
+      else if (colDefWidth.match(/^\*+$/)) {
+        self.width = colDefWidth;
+      }
+      // No idea, throw an Error
       else {
-        // If the width is not a number
-        if (!angular.isNumber(colDef.width)) {
-          // See if it ends with a percent
-          if (gridUtil.endsWith(colDef.width, '%')) {
-            // If so we should be able to parse the non-percent-sign part to a number
-            var percentStr = colDef.width.replace(/%/g, '');
-            var percent = parseInt(percentStr, 10);
-            if (isNaN(percent)) {
-              throw new Error(parseErrorMsg);
-            }
-            self.width = colDef.width;
-          }
-          // And see if it's a number string
-          else if (colDef.width.match(/^(\d+)$/)) {
-            self.width = parseInt(colDef.width.match(/^(\d+)$/)[1], 10);
-          }
-          // Otherwise it should be a string of asterisks
-          else if (colDef.width.match(/^\*+$/)) {
-            self.width = colDef.width;
-          }
-          // No idea, throw an Error
-          else {
-            throw new Error(parseErrorMsg);
-          }
-        }
-        // Is a number, use it as the width
-        else {
-          self.width = colDef.width;
-        }
+        throw new Error(parseErrorMsg);
       }
+    }
+    // Is a number, use it as the width
+    else {
+      self.width = colDefWidth;
     }
 
     self.minWidth = !colDef.minWidth ? 30 : colDef.minWidth;

--- a/test/unit/core/factories/GridColumn.spec.js
+++ b/test/unit/core/factories/GridColumn.spec.js
@@ -529,4 +529,57 @@ describe('GridColumn factory', function () {
       });
     });
   });
+
+  describe('updateColumnDef(colDef, isNew)', function () {
+    var col, colDef;
+
+    beforeEach(function () {
+      col = grid.columns[0];
+      colDef = angular.copy(col.colDef);
+      col.width = 141;
+    });
+
+    it ('should set the value of width to * when colDef.width is undefined', invalidColDef(undefined));
+    it ('should set the value of width to * when colDef.width is null', invalidColDef(null));
+    it ('should set the value of width to * when colDef.width is an object', invalidColDef({}));
+    it ('should set the value of width to colDef.width when it is a percentage', widthEqualsColDefWidth('10.1%'));
+
+    it ('should set the value of width to the persed integer colDef.width when it is a string', function () {
+      colDef.width = '42';
+      col.updateColumnDef(colDef);
+      expect(col.width).toBe(42);
+    });
+
+    it ('should set the value of width to colDef.width when it is a series of *', widthEqualsColDefWidth('***'));
+    it ('should set the value of width to colDef.width when it is a number', widthEqualsColDefWidth(42));
+
+    it ('should throw when colDef.width is an invalid string', function () {
+      colDef.width = 'e1%';
+      expect(updateCol(colDef.width)).toThrow();
+      colDef.width = '#FFF';
+      expect(updateCol(colDef.width)).toThrow();
+    });
+
+    function widthEqualsColDefWidth(expected) {
+      return function () {
+        colDef.width = expected;
+        col.updateColumnDef(colDef);
+        expect(col.width).toBe(expected);
+      };
+    }
+
+    function invalidColDef(width) {
+      return function () {
+        colDef.width = width;
+        col.updateColumnDef(colDef);
+        expect(col.width).toBe('*');
+      };
+    }
+
+    function updateCol(col, colDef) {
+      return function () {
+        col.updateColumnDef(colDef);
+      };
+    }
+  });
 });


### PR DESCRIPTION
This fixes issue #3880. The width of the column definition should have precedence over the current column width.

Maybe it'd be better to put that block of code into a separated method?

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular-ui/ng-grid/3897)
<!-- Reviewable:end -->
