### PR TITLE
Fixes documentation example bug in pagination.js

### DIFF
--- a/src/features/pagination/js/pagination.js
+++ b/src/features/pagination/js/pagination.js
@@ -293,7 +293,7 @@
         columnDefs: [
           {name: 'name'},
           {name: 'car'}
-        ];
+        ]
        }
     }]);
    </file>


### PR DESCRIPTION
There was a `;` that caused the example to fail to run.
Closes #3945

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular-ui/ng-grid/3949)
<!-- Reviewable:end -->
