### PR TITLE
Convert menu item title names to readable column names

### DIFF
--- a/src/js/core/directives/ui-grid-menu-button.js
+++ b/src/js/core/directives/ui-grid-menu-button.js
@@ -300,7 +300,7 @@ angular.module('ui.grid')
      * 
      */
     setMenuItemTitle: function( menuItem, colDef, grid ){
-      var title = grid.options.gridMenuTitleFilter( colDef.displayName || colDef.name || colDef.field );
+      var title = grid.options.gridMenuTitleFilter( colDef.displayName || gridUtil.readableColumnName(colDef.name) || colDef.field );
       
       if ( typeof(title) === 'string' ){
         menuItem.title = title;


### PR DESCRIPTION
If the columnDef config object doesn't include a displayName property and grid.options.enableGridMenu = true, the grid menu titles default to the name property provided in the columnDef config object. This results in an inconsistency between the column headers and the grid menu titles.

More specifically, the column headers are converted to friendly display names via gridUtil.readableColumnName, whereas the menu titles simply display the name property.  

To remain consistent, the menu title should also create a friendly display name via gridUtil.readableColumnName.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular-ui/ng-grid/3979)
<!-- Reviewable:end -->
